### PR TITLE
Update `jspdf` to version 3.0.4, fixing depdency review issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11747,12 +11747,12 @@
       }
     },
     "node_modules/jspdf": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.3.tgz",
-      "integrity": "sha512-eURjAyz5iX1H8BOYAfzvdPfIKK53V7mCpBTe7Kb16PaM8JSXEcUQNBQaiWMI8wY5RvNOPj4GccMjTlfwRBd+oQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.4.tgz",
+      "integrity": "sha512-dc6oQ8y37rRcHn316s4ngz/nOjayLF/FFxBF4V9zamQKRqXxyiH1zagkCdktdWhtoQId5K20xt1lB90XzkB+hQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.26.9",
+        "@babel/runtime": "^7.28.4",
         "fast-png": "^6.2.0",
         "fflate": "^0.8.1"
       },

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
   },
   "overrides": {
     "@types/react": "19.2.2",
-    "@types/react-dom": "19.2.2"
+    "@types/react-dom": "19.2.2",
+    "jspdf": "3.0.4"
   }
 }


### PR DESCRIPTION
This is to fix an issue with the dependency review.