### PR TITLE
Update dependencies `html2pdf.js` and `monaco-editor` for vulnerabili…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "fluent-ffmpeg": "^2.1.3",
         "he": "^1.2.0",
         "html-to-docx": "^1.8.0",
-        "html2pdf.js": "^0.12.1",
+        "html2pdf.js": "^0.13.0",
         "isomorphic-dompurify": "^2.31.0",
         "katex": "^0.16.25",
         "launchdarkly-react-client-sdk": "^3.6.1",
@@ -52,7 +52,7 @@
         "mermaid": "^11.12.1",
         "microsoft-cognitiveservices-speech-sdk": "^1.46.0",
         "mime-types": "^2.1.35",
-        "monaco-editor": "^0.54.0",
+        "monaco-editor": "^0.55.1",
         "next": "^16.0.8",
         "next-auth": "^5.0.0-beta.30",
         "openai": "^6.7.0",
@@ -7642,9 +7642,9 @@
       "license": "MIT"
     },
     "node_modules/core-js": {
-      "version": "3.46.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.46.0.tgz",
-      "integrity": "sha512-vDMm9B0xnqqZ8uSBpZ8sNtRtOdmfShrvT6h2TuQGLs0Is+cR0DYbj/KWP6ALVNbWPpqA/qPLoOuppJN07humpA==",
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.47.0.tgz",
+      "integrity": "sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -10590,13 +10590,13 @@
       }
     },
     "node_modules/html2pdf.js": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/html2pdf.js/-/html2pdf.js-0.12.1.tgz",
-      "integrity": "sha512-3rBWQ96H5oOU9jtoz3MnE/epGi27ig9h8aonBk4JTpvUERM3lMRxhIRckhJZEi4wE0YfRINoYOIDY0hLY0CHgQ==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/html2pdf.js/-/html2pdf.js-0.13.0.tgz",
+      "integrity": "sha512-m/U8XqxJIfEfu5GhxRNHk3aqt/gQXoJrVY9nHHBQfYnWEobDXaYEbd50KiU61x7P/BpSiL2MSuFQ84rrDKVfcA==",
       "license": "MIT",
       "dependencies": {
         "html2canvas": "^1.0.0",
-        "jspdf": "^3.0.0"
+        "jspdf": "^4.0.0"
       }
     },
     "node_modules/htmlparser2": {
@@ -11747,9 +11747,9 @@
       }
     },
     "node_modules/jspdf": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.4.tgz",
-      "integrity": "sha512-dc6oQ8y37rRcHn316s4ngz/nOjayLF/FFxBF4V9zamQKRqXxyiH1zagkCdktdWhtoQId5K20xt1lB90XzkB+hQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.0.0.tgz",
+      "integrity": "sha512-w12U97Z6edKd2tXDn3LzTLg7C7QLJlx0BPfM3ecjK2BckUl9/81vZ+r5gK4/3KQdhAcEZhENUxRhtgYBj75MqQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
@@ -13615,20 +13615,23 @@
       "license": "MIT"
     },
     "node_modules/monaco-editor": {
-      "version": "0.54.0",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.54.0.tgz",
-      "integrity": "sha512-hx45SEUoLatgWxHKCmlLJH81xBo0uXP4sRkESUpmDQevfi+e7K1VuiSprK6UpQ8u4zOcKNiH0pMvHvlMWA/4cw==",
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
       "dependencies": {
-        "dompurify": "3.1.7",
+        "dompurify": "3.2.7",
         "marked": "14.0.0"
       }
     },
     "node_modules/monaco-editor/node_modules/dompurify": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
-      "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==",
-      "license": "(MPL-2.0 OR Apache-2.0)"
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/monaco-editor/node_modules/marked": {
       "version": "14.0.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "fluent-ffmpeg": "^2.1.3",
     "he": "^1.2.0",
     "html-to-docx": "^1.8.0",
-    "html2pdf.js": "^0.12.1",
+    "html2pdf.js": "^0.13.0",
     "isomorphic-dompurify": "^2.31.0",
     "katex": "^0.16.25",
     "launchdarkly-react-client-sdk": "^3.6.1",
@@ -63,7 +63,7 @@
     "mermaid": "^11.12.1",
     "microsoft-cognitiveservices-speech-sdk": "^1.46.0",
     "mime-types": "^2.1.35",
-    "monaco-editor": "^0.54.0",
+    "monaco-editor": "^0.55.1",
     "next": "^16.0.8",
     "next-auth": "^5.0.0-beta.30",
     "openai": "^6.7.0",
@@ -123,7 +123,6 @@
   },
   "overrides": {
     "@types/react": "19.2.2",
-    "@types/react-dom": "19.2.2",
-    "jspdf": "3.0.4"
+    "@types/react-dom": "19.2.2"
   }
 }


### PR DESCRIPTION
…ties

- Bumped `html2pdf.js` from `0.12.1` to `0.13.0` with updated `jspdf` dependency (`4.0.0`).
- Upgraded `monaco-editor` from `0.54.0` to `0.55.1`, including `dompurify` (`3.2.7`).
- Updated `core-js` from `3.46.0` to `3.47.0`.
- Removed `jspdf` direct override in `package.json` (fixed by html2pfd.js upgrade)