### PR TITLE
Bug/transcription iphone issue

### DIFF
--- a/__tests__/app/api/transcription-queue.test.ts
+++ b/__tests__/app/api/transcription-queue.test.ts
@@ -46,6 +46,8 @@ describe('/api/transcription/queue', () => {
   const mockQueueClient = {
     peekMessages: vi.fn(),
     receiveMessages: vi.fn(),
+    // Used to restore visibility of scanned non-target messages.
+    updateMessage: vi.fn(),
     exists: vi.fn(),
   };
 
@@ -208,7 +210,7 @@ describe('/api/transcription/queue', () => {
       const data = await parseJsonResponse(response);
 
       expect(response.status).toBe(404);
-      expect(data.error).toContain('Message not found in queue');
+      expect(data.error).toContain('Message not found');
     });
 
     it('returns 403 when message belongs to different user', async () => {
@@ -232,7 +234,10 @@ describe('/api/transcription/queue', () => {
       expect(data.message).toContain('Forbidden');
     });
 
-    it('handles pagination for large queues', async () => {
+    it('peeks the queue exactly once — Azure peek has no pagination cursor', async () => {
+      // Repeated peeks return the same front-of-queue page, so "paging"
+      // with peek would loop over identical data. The route must do a
+      // single deep peek and report a bounded 404 instead.
       const createMessage = (id: string) =>
         Buffer.from(
           JSON.stringify({
@@ -242,38 +247,32 @@ describe('/api/transcription/queue', () => {
           }),
         ).toString('base64');
 
-      // First page: 32 messages
       const firstPage = Array.from({ length: 32 }, (_, i) => ({
         messageText: createMessage(`msg-${i}`),
       }));
 
-      // Second page: target message
-      const secondPage = [
-        {
-          messageText: createMessage('target-msg'),
-        },
-      ];
-
-      mockQueueClient.peekMessages
-        .mockResolvedValueOnce({ peekedMessageItems: firstPage })
-        .mockResolvedValueOnce({ peekedMessageItems: secondPage });
+      mockQueueClient.peekMessages.mockResolvedValue({
+        peekedMessageItems: firstPage,
+      });
 
       const request = createGetRequest('target-msg', 'transcription');
       const response = await GET(request);
       const data = await parseJsonResponse(response);
 
-      expect(data.position).toBe(33); // 32 + 1
+      expect(response.status).toBe(404);
+      expect(data.error).toContain('first 32');
+      expect(mockQueueClient.peekMessages).toHaveBeenCalledTimes(1);
     });
 
-    it('returns 500 when not authenticated', async () => {
+    it('returns 401 when not authenticated', async () => {
       (vi.mocked(auth) as any).mockResolvedValue(null);
 
       const request = createGetRequest('msg-123', 'transcription');
       const response = await GET(request);
       const data = await parseJsonResponse(response);
 
-      expect(response.status).toBe(500);
-      expect(data.error).toBe('Internal Server Error');
+      expect(response.status).toBe(401);
+      expect(data.error).toBe('Unauthorized');
     });
 
     it('returns 401 for unauthorized errors', async () => {
@@ -483,7 +482,7 @@ describe('/api/transcription/queue', () => {
       expect(decodedMessage.message).toEqual(complexMessage);
     });
 
-    it('returns 500 when not authenticated', async () => {
+    it('returns 401 when not authenticated', async () => {
       (vi.mocked(auth) as any).mockResolvedValue(null);
 
       const request = createPostRequest({
@@ -493,8 +492,8 @@ describe('/api/transcription/queue', () => {
       const response = await POST(request);
       const data = await parseJsonResponse(response);
 
-      expect(response.status).toBe(500);
-      expect(data.error).toBe('Internal Server Error');
+      expect(response.status).toBe(401);
+      expect(data.error).toBe('Unauthorized');
     });
 
     it('returns 500 for queue operation errors', async () => {
@@ -689,7 +688,7 @@ describe('/api/transcription/queue', () => {
       expect(data.error).toBe('Forbidden');
     });
 
-    it('returns 500 when not authenticated', async () => {
+    it('returns 401 when not authenticated', async () => {
       (vi.mocked(auth) as any).mockResolvedValue(null);
 
       const request = createPatchRequest({
@@ -700,8 +699,54 @@ describe('/api/transcription/queue', () => {
       const response = await PATCH(request);
       const data = await parseJsonResponse(response);
 
-      expect(response.status).toBe(500);
-      expect(data.error).toBe('Internal Server Error');
+      expect(response.status).toBe(401);
+      expect(data.error).toBe('Unauthorized');
+    });
+
+    it('restores visibility of scanned non-target messages', async () => {
+      const createMessage = (id: string, userId = 'test-user-id') =>
+        Buffer.from(
+          JSON.stringify({ messageId: id, userId, message: `m-${id}` }),
+        ).toString('base64');
+
+      // One page containing two foreign-to-the-search messages + the target.
+      mockQueueClient.receiveMessages.mockResolvedValue({
+        receivedMessageItems: [
+          {
+            messageId: 'azure-1',
+            popReceipt: 'pr-1',
+            messageText: createMessage('other-1'),
+          },
+          {
+            messageId: 'azure-2',
+            popReceipt: 'pr-2',
+            messageText: createMessage('other-2'),
+          },
+          {
+            messageId: 'azure-3',
+            popReceipt: 'pr-3',
+            messageText: createMessage('msg-123'),
+          },
+        ],
+      });
+
+      const request = createPatchRequest({
+        messageId: 'msg-123',
+        category: 'transcription',
+        message: 'Updated',
+      });
+      const response = await PATCH(request);
+
+      expect(response.status).toBe(200);
+      // Both non-target messages must be made visible again (timeout 0) so
+      // real consumers don't stall behind our scan.
+      const restoredIds = mockQueueClient.updateMessage.mock.calls.map(
+        (call) => call[0],
+      );
+      expect(restoredIds.sort()).toEqual(['azure-1', 'azure-2']);
+      for (const call of mockQueueClient.updateMessage.mock.calls) {
+        expect(call[3]).toBe(0); // visibilityTimeout
+      }
     });
   });
 
@@ -819,15 +864,15 @@ describe('/api/transcription/queue', () => {
       expect(data.error).toBe('Forbidden');
     });
 
-    it('returns 500 when not authenticated', async () => {
+    it('returns 401 when not authenticated', async () => {
       (vi.mocked(auth) as any).mockResolvedValue(null);
 
       const request = createDeleteRequest('msg-123', 'transcription');
       const response = await DELETE(request);
       const data = await parseJsonResponse(response);
 
-      expect(response.status).toBe(500);
-      expect(data.error).toBe('Internal Server Error');
+      expect(response.status).toBe(401);
+      expect(data.error).toBe('Unauthorized');
     });
 
     it('returns 500 for queue operation errors', async () => {

--- a/__tests__/app/api/user-profile.test.ts
+++ b/__tests__/app/api/user-profile.test.ts
@@ -1,3 +1,4 @@
+import { getToken } from 'next-auth/jwt';
 import { NextRequest } from 'next/server';
 
 import { GET } from '@/app/api/user/profile/route';
@@ -6,6 +7,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // Mock auth
 vi.mock('@/auth', () => ({
   auth: vi.fn(),
+}));
+
+// The route reads the refresh token from the JWT via getToken(), not from
+// the session (it is deliberately never exposed there).
+vi.mock('next-auth/jwt', () => ({
+  getToken: vi.fn(),
 }));
 
 // Mock global fetch
@@ -17,6 +24,10 @@ describe('GET /api/user/profile', () => {
     process.env.AZURE_TENANT_ID = 'test-tenant-id';
     process.env.AZURE_CLIENT_ID = 'test-client-id';
     process.env.AZURE_CLIENT_SECRET = 'test-client-secret';
+    // Default to a JWT carrying a refresh token; individual tests override.
+    vi.mocked(getToken).mockResolvedValue({
+      refreshToken: 'test-refresh-token',
+    } as any);
   });
 
   const createMockRequest = () => {
@@ -52,8 +63,8 @@ describe('GET /api/user/profile', () => {
       const { auth } = await import('@/auth');
       vi.mocked(auth).mockResolvedValue({
         user: { id: 'test-user' },
-        refreshToken: null,
       } as any);
+      vi.mocked(getToken).mockResolvedValue({ refreshToken: null } as any);
 
       const request = createMockRequest();
       const response = await GET(request);
@@ -69,7 +80,6 @@ describe('GET /api/user/profile', () => {
       const { auth } = await import('@/auth');
       vi.mocked(auth).mockResolvedValue({
         user: { id: 'test-user' },
-        refreshToken: 'test-refresh-token',
       } as any);
 
       // Mock token refresh response
@@ -109,7 +119,6 @@ describe('GET /api/user/profile', () => {
       const { auth } = await import('@/auth');
       vi.mocked(auth).mockResolvedValue({
         user: { id: 'test-user' },
-        refreshToken: 'test-refresh-token',
       } as any);
 
       // Mock failed token refresh
@@ -129,7 +138,6 @@ describe('GET /api/user/profile', () => {
       const { auth } = await import('@/auth');
       vi.mocked(auth).mockResolvedValue({
         user: { id: 'test-user' },
-        refreshToken: 'test-refresh-token',
       } as any);
 
       // Mock token refresh throwing error
@@ -149,7 +157,6 @@ describe('GET /api/user/profile', () => {
       const { auth } = await import('@/auth');
       vi.mocked(auth).mockResolvedValue({
         user: { id: 'test-user' },
-        refreshToken: 'test-refresh-token',
       } as any);
 
       const mockUserData = {
@@ -194,7 +201,6 @@ describe('GET /api/user/profile', () => {
       const { auth } = await import('@/auth');
       vi.mocked(auth).mockResolvedValue({
         user: { id: 'test-user' },
-        refreshToken: 'test-refresh-token',
       } as any);
 
       // Mock token refresh
@@ -233,7 +239,6 @@ describe('GET /api/user/profile', () => {
       const { auth } = await import('@/auth');
       vi.mocked(auth).mockResolvedValue({
         user: { id: 'test-user' },
-        refreshToken: 'test-refresh-token',
       } as any);
 
       // Mock token refresh
@@ -271,7 +276,6 @@ describe('GET /api/user/profile', () => {
       const { auth } = await import('@/auth');
       vi.mocked(auth).mockResolvedValue({
         user: { id: 'test-user' },
-        refreshToken: 'test-refresh-token',
       } as any);
 
       // Mock token refresh
@@ -300,7 +304,6 @@ describe('GET /api/user/profile', () => {
       const { auth } = await import('@/auth');
       vi.mocked(auth).mockResolvedValue({
         user: { id: 'test-user' },
-        refreshToken: 'test-refresh-token',
       } as any);
 
       // Mock token refresh
@@ -332,7 +335,6 @@ describe('GET /api/user/profile', () => {
       const { auth } = await import('@/auth');
       vi.mocked(auth).mockResolvedValue({
         user: { id: 'test-user' },
-        refreshToken: 'test-refresh-token',
       } as any);
 
       // Mock token refresh
@@ -360,7 +362,6 @@ describe('GET /api/user/profile', () => {
       const { auth } = await import('@/auth');
       vi.mocked(auth).mockResolvedValue({
         user: { id: 'test-user' },
-        refreshToken: 'test-refresh-token',
       } as any);
 
       // Mock token refresh

--- a/__tests__/client/stores/chatStore.fallbackChain.test.tsx
+++ b/__tests__/client/stores/chatStore.fallbackChain.test.tsx
@@ -1,0 +1,244 @@
+import { Conversation } from '@/types/chat';
+import { OpenAIModelID, OpenAIModels } from '@/types/openai';
+
+import { ApiError } from '@/client/services';
+import { useChatStore } from '@/client/stores/chatStore';
+import { getFallbackChain } from '@/config/models';
+import '@testing-library/jest-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-hot-toast', () => ({
+  default: {
+    loading: vi.fn(() => 'toast-id'),
+    success: vi.fn(),
+    error: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+
+/**
+ * Tests for the error-fallback chain.
+ *
+ * The historical bug: the single fallback model was identical to the default
+ * model, so users on the default model never got an auto-retry at all, and a
+ * default-model outage had no alternative to fall back to. These tests pin
+ * the fixed behavior: retry fires for default-model users, walks the chain
+ * past failing models, and stops on errors that would fail on every model.
+ */
+describe('ChatStore - fallback chain', () => {
+  const initialState = useChatStore.getState();
+
+  const makeConversation = (modelId: OpenAIModelID): Conversation =>
+    ({
+      id: 'conv-1',
+      name: 'Test conversation',
+      messages: [{ role: 'user', content: 'hello' }],
+      model: OpenAIModels[modelId],
+      prompt: '',
+      temperature: 1,
+      folderId: null,
+    }) as unknown as Conversation;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useChatStore.setState(initialState, true);
+  });
+
+  describe('handleSendError', () => {
+    it('auto-retries when the conversation uses the default model (regression)', () => {
+      const retrySpy = vi.fn().mockResolvedValue(undefined);
+      useChatStore.setState({ retryWithFallbackModel: retrySpy });
+      const conversation = makeConversation(OpenAIModelID.GPT_5_2_CHAT);
+
+      useChatStore
+        .getState()
+        .handleSendError(
+          new ApiError('boom', 500, 'Internal Server Error'),
+          conversation,
+        );
+
+      expect(retrySpy).toHaveBeenCalledTimes(1);
+      expect(retrySpy).toHaveBeenCalledWith(conversation, undefined);
+    });
+
+    it('auto-retries on rate limiting (429)', () => {
+      const retrySpy = vi.fn().mockResolvedValue(undefined);
+      useChatStore.setState({ retryWithFallbackModel: retrySpy });
+
+      useChatStore
+        .getState()
+        .handleSendError(
+          new ApiError('slow down', 429, 'Too Many Requests'),
+          makeConversation(OpenAIModelID.GPT_5_2_CHAT),
+        );
+
+      expect(retrySpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not retry on non-429 client errors — they fail on every model', () => {
+      const retrySpy = vi.fn().mockResolvedValue(undefined);
+      useChatStore.setState({ retryWithFallbackModel: retrySpy });
+
+      useChatStore
+        .getState()
+        .handleSendError(
+          new ApiError('bad payload', 400, 'Bad Request'),
+          makeConversation(OpenAIModelID.GPT_5_2_CHAT),
+        );
+
+      expect(retrySpy).not.toHaveBeenCalled();
+      expect(useChatStore.getState().error).toBeTruthy();
+    });
+
+    it('does not retry on auth errors', () => {
+      const retrySpy = vi.fn().mockResolvedValue(undefined);
+      useChatStore.setState({ retryWithFallbackModel: retrySpy });
+
+      useChatStore
+        .getState()
+        .handleSendError(
+          new ApiError('unauthorized', 401, 'Unauthorized'),
+          makeConversation(OpenAIModelID.GPT_5_2_CHAT),
+        );
+
+      expect(retrySpy).not.toHaveBeenCalled();
+    });
+
+    it('does not retry custom agents', () => {
+      const retrySpy = vi.fn().mockResolvedValue(undefined);
+      useChatStore.setState({ retryWithFallbackModel: retrySpy });
+      const conversation = {
+        ...makeConversation(OpenAIModelID.GPT_5_2_CHAT),
+        model: { id: 'custom-abc', name: 'My Agent' },
+      } as unknown as Conversation;
+
+      useChatStore
+        .getState()
+        .handleSendError(new ApiError('boom', 500, 'ISE'), conversation);
+
+      expect(retrySpy).not.toHaveBeenCalled();
+    });
+
+    it('does not start a second retry while one is in flight', () => {
+      const retrySpy = vi.fn().mockResolvedValue(undefined);
+      useChatStore.setState({
+        retryWithFallbackModel: retrySpy,
+        isRetrying: true,
+      });
+
+      useChatStore
+        .getState()
+        .handleSendError(
+          new ApiError('boom', 500, 'ISE'),
+          makeConversation(OpenAIModelID.GPT_5_2_CHAT),
+        );
+
+      expect(retrySpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('retryWithFallbackModel chain walking', () => {
+    it('tries every remaining chain model in order when all of them fail', async () => {
+      const sendSpy = vi
+        .fn()
+        .mockRejectedValue(new ApiError('boom', 500, 'Internal Server Error'));
+      useChatStore.setState({ sendChatRequest: sendSpy });
+      const conversation = makeConversation(OpenAIModelID.GPT_5_2_CHAT);
+
+      await useChatStore.getState().retryWithFallbackModel(conversation);
+
+      const expectedOrder = getFallbackChain().filter(
+        (id) => id !== OpenAIModelID.GPT_5_2_CHAT,
+      );
+      const attemptedOrder = sendSpy.mock.calls.map(
+        (call) => (call[0] as Conversation).model.id,
+      );
+      expect(attemptedOrder).toEqual(expectedOrder);
+
+      const state = useChatStore.getState();
+      expect(state.isRetrying).toBe(false);
+      expect(state.error).toBeTruthy();
+      expect(state.showModelSwitchPrompt).toBe(false);
+    });
+
+    it('stops and records the successful model when a later chain entry works', async () => {
+      const stream = () =>
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('Hello there'));
+            controller.close();
+          },
+        });
+      const sendSpy = vi
+        .fn()
+        .mockRejectedValueOnce(new ApiError('boom', 500, 'ISE'))
+        .mockResolvedValueOnce(stream());
+      useChatStore.setState({ sendChatRequest: sendSpy });
+      const conversation = makeConversation(OpenAIModelID.GPT_5_2_CHAT);
+
+      await useChatStore.getState().retryWithFallbackModel(conversation);
+
+      const chainAfterDefault = getFallbackChain().filter(
+        (id) => id !== OpenAIModelID.GPT_5_2_CHAT,
+      );
+      expect(sendSpy).toHaveBeenCalledTimes(2);
+
+      const state = useChatStore.getState();
+      expect(state.successfulFallbackModelId).toBe(chainAfterDefault[1]);
+      expect(state.showModelSwitchPrompt).toBe(true);
+      expect(state.originalModelId).toBe(OpenAIModelID.GPT_5_2_CHAT);
+      expect(state.isRetrying).toBe(false);
+      expect(state.error).toBeNull();
+    });
+
+    it('stops the chain when the user aborts mid-retry', async () => {
+      const abortError = new Error('aborted');
+      abortError.name = 'AbortError';
+      const sendSpy = vi.fn().mockRejectedValue(abortError);
+      useChatStore.setState({ sendChatRequest: sendSpy });
+
+      await useChatStore
+        .getState()
+        .retryWithFallbackModel(makeConversation(OpenAIModelID.GPT_5_2_CHAT));
+
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+      const state = useChatStore.getState();
+      expect(state.error).toBeNull();
+      expect(state.isRetrying).toBe(false);
+    });
+
+    it('stops the chain on a non-retryable client error', async () => {
+      const sendSpy = vi
+        .fn()
+        .mockRejectedValue(new ApiError('bad payload', 400, 'Bad Request'));
+      useChatStore.setState({ sendChatRequest: sendSpy });
+
+      await useChatStore
+        .getState()
+        .retryWithFallbackModel(makeConversation(OpenAIModelID.GPT_5_2_CHAT));
+
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+      const state = useChatStore.getState();
+      expect(state.error).toBeTruthy();
+      expect(state.isRetrying).toBe(false);
+    });
+
+    it('gives up immediately when every chain model has been attempted', async () => {
+      const sendSpy = vi.fn();
+      useChatStore.setState({ sendChatRequest: sendSpy });
+
+      await useChatStore
+        .getState()
+        .retryWithFallbackModel(
+          makeConversation(OpenAIModelID.GPT_5_2_CHAT),
+          undefined,
+          getFallbackChain(),
+        );
+
+      expect(sendSpy).not.toHaveBeenCalled();
+      const state = useChatStore.getState();
+      expect(state.error).toBeTruthy();
+      expect(state.isRetrying).toBe(false);
+    });
+  });
+});

--- a/__tests__/config/models.test.ts
+++ b/__tests__/config/models.test.ts
@@ -1,6 +1,10 @@
+import { OpenAIModelID } from '@/types/openai';
+
 import {
   getCurrentEnvironment,
   getDefaultModel,
+  getFallbackChain,
+  getFallbackModel,
   getModelConfig,
   isModelDisabled,
 } from '@/config/models';
@@ -95,6 +99,56 @@ describe('Model Configuration', () => {
     it('handles undefined gracefully', () => {
       vi.stubEnv('NEXT_PUBLIC_ENV', 'localhost');
       expect(isModelDisabled('test-model')).toBe(false);
+    });
+  });
+
+  describe('getFallbackChain', () => {
+    it('starts with the default model', () => {
+      vi.stubEnv('NEXT_PUBLIC_ENV', 'prod');
+      expect(getFallbackChain()[0]).toBe(getDefaultModel());
+    });
+
+    it('contains more than one model so default-model outages have a fallback', () => {
+      vi.stubEnv('NEXT_PUBLIC_ENV', 'prod');
+      expect(getFallbackChain().length).toBeGreaterThan(1);
+    });
+  });
+
+  describe('getFallbackModel', () => {
+    beforeEach(() => {
+      vi.stubEnv('NEXT_PUBLIC_ENV', 'localhost');
+    });
+
+    it('returns the first chain model when nothing is excluded', () => {
+      expect(getFallbackModel([])?.id).toBe(OpenAIModelID.GPT_5_2_CHAT);
+    });
+
+    it('skips the model that just failed', () => {
+      const fallback = getFallbackModel([OpenAIModelID.GPT_5_2_CHAT]);
+      expect(fallback).not.toBeNull();
+      expect(fallback?.id).not.toBe(OpenAIModelID.GPT_5_2_CHAT);
+      expect(fallback?.id).toBe(getFallbackChain()[1]);
+    });
+
+    it('walks past every already-attempted model', () => {
+      const chain = getFallbackChain();
+      const attempted = chain.slice(0, chain.length - 1);
+      expect(getFallbackModel(attempted)?.id).toBe(chain[chain.length - 1]);
+    });
+
+    it('returns null when the whole chain has been attempted', () => {
+      expect(getFallbackModel(getFallbackChain())).toBeNull();
+    });
+
+    it('never returns a model from the exclude list', () => {
+      const chain = getFallbackChain();
+      for (let i = 0; i < chain.length; i++) {
+        const excluded = chain.slice(0, i + 1);
+        const fallback = getFallbackModel(excluded);
+        if (fallback) {
+          expect(excluded).not.toContain(fallback.id);
+        }
+      }
     });
   });
 

--- a/__tests__/lib/services/chat/processors/FileProcessor.test.ts
+++ b/__tests__/lib/services/chat/processors/FileProcessor.test.ts
@@ -289,6 +289,45 @@ describe('FileProcessor', () => {
       );
     });
 
+    it('cleans up every downloaded temp file when a file fails processing', async () => {
+      // Regression: cleanup used to run only on the happy path, so one
+      // failing file stranded every downloaded temp file (multi-GB for
+      // audio/video) in /tmp.
+      const context = createTestChatContext({
+        hasFiles: true,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'file_url',
+                url: 'https://blob.com/file1.txt',
+                originalFilename: 'file1.txt',
+              },
+              {
+                type: 'file_url',
+                url: 'https://blob.com/file2.txt',
+                originalFilename: 'file2.txt',
+              },
+            ],
+            messageType: MessageType.FILE,
+          },
+        ],
+      });
+
+      // Both files download fine; the first fails during processing.
+      mockLoadDocument.mockRejectedValueOnce(new Error('corrupt document'));
+
+      // BasePipelineStage.execute converts stage failures into context.errors.
+      const result = await fileProcessor.execute(context);
+      expect(result.errors?.length).toBeGreaterThan(0);
+
+      const cleanedPaths = mockFileService.cleanupFile.mock.calls.map(
+        (call: string[]) => call[0],
+      );
+      expect(cleanedPaths.sort()).toEqual(['/tmp/file1.txt', '/tmp/file2.txt']);
+    });
+
     it('should skip stage when no files present', async () => {
       const context = createTestChatContext({
         hasFiles: false,

--- a/__tests__/lib/services/transcription/batchJobRegistry.test.ts
+++ b/__tests__/lib/services/transcription/batchJobRegistry.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for the batch transcription job ownership registry.
+ *
+ * Uses the real filesystem (/tmp/batch-transcription-jobs) with random
+ * UUIDs per test, mirroring how the registry runs in production.
+ */
+import {
+  deleteBatchJobRecord,
+  getBatchJobOwner,
+  recordBatchJobOwner,
+  userOwnsBatchJob,
+} from '@/lib/services/transcription/batchJobRegistry';
+
+import { randomUUID } from 'crypto';
+import { afterEach, describe, expect, it } from 'vitest';
+
+describe('batchJobRegistry', () => {
+  const created: string[] = [];
+
+  function freshJobId(): string {
+    const jobId = randomUUID();
+    created.push(jobId);
+    return jobId;
+  }
+
+  afterEach(() => {
+    for (const jobId of created.splice(0)) {
+      deleteBatchJobRecord(jobId);
+    }
+  });
+
+  it('round-trips owner records', () => {
+    const jobId = freshJobId();
+    recordBatchJobOwner(jobId, 'user-a');
+    expect(getBatchJobOwner(jobId)).toBe('user-a');
+  });
+
+  it('grants access only to the recorded owner', () => {
+    const jobId = freshJobId();
+    recordBatchJobOwner(jobId, 'user-a');
+    expect(userOwnsBatchJob(jobId, 'user-a')).toBe(true);
+    expect(userOwnsBatchJob(jobId, 'user-b')).toBe(false);
+  });
+
+  it('denies access to unregistered jobs (deny-unknown policy)', () => {
+    // An unknown GUID is more likely a probe than a legitimate pre-registry
+    // job; routes turn this denial into an indistinguishable 404.
+    expect(userOwnsBatchJob(randomUUID(), 'user-a')).toBe(false);
+  });
+
+  it('removes records on delete', () => {
+    const jobId = freshJobId();
+    recordBatchJobOwner(jobId, 'user-a');
+    deleteBatchJobRecord(jobId);
+    expect(getBatchJobOwner(jobId)).toBeUndefined();
+  });
+
+  it('never throws on malformed job IDs (registry is best-effort)', () => {
+    expect(() => recordBatchJobOwner('../escape', 'user-a')).not.toThrow();
+    expect(getBatchJobOwner('../escape')).toBeUndefined();
+    expect(userOwnsBatchJob('../escape', 'user-a')).toBe(false);
+  });
+});

--- a/__tests__/lib/services/transcription/chunkedJobStore.test.ts
+++ b/__tests__/lib/services/transcription/chunkedJobStore.test.ts
@@ -7,9 +7,11 @@ import {
   getJob,
   getJobForUser,
   markInterruptedJobsFailed,
+  sweepOrphanedChunkDirs,
   updateProgress,
 } from '@/lib/services/transcription/chunkedJobStore';
 
+import * as os from 'os';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // The store hardcodes its directory; mock fs so each test sees an isolated
@@ -17,9 +19,30 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const memoryFs = new Map<string, string>();
 
 vi.mock('fs', () => {
-  const mkdirSync = vi.fn();
+  // Lock dirs created by acquireJobLock; tracked so re-acquisition conflicts
+  // behave like the real fs (mkdirSync throws when the dir exists).
+  const dirs = new Set<string>();
+  const mkdirSync = vi.fn((p: string, opts?: { recursive?: boolean }) => {
+    if (dirs.has(p) && !opts?.recursive) {
+      throw new Error(`EEXIST: ${p}`);
+    }
+    dirs.add(p);
+  });
+  const rmdirSync = vi.fn((p: string) => {
+    dirs.delete(p);
+  });
+  const statSync = vi.fn((p: string) => {
+    if (!dirs.has(p) && !memoryFs.has(p)) throw new Error(`ENOENT: ${p}`);
+    return { mtimeMs: Date.now() };
+  });
+  const rmSync = vi.fn((p: string) => {
+    dirs.delete(p);
+    for (const key of [...memoryFs.keys()]) {
+      if (key === p || key.startsWith(p + '/')) memoryFs.delete(key);
+    }
+  });
   const existsSync = (p: string) =>
-    memoryFs.has(p) || p === '/tmp/chunked-transcription-jobs';
+    memoryFs.has(p) || dirs.has(p) || p === '/tmp/chunked-transcription-jobs';
   const writeFileSync = (p: string, data: string) => {
     memoryFs.set(p, data);
   };
@@ -35,15 +58,29 @@ vi.mock('fs', () => {
     return v;
   };
   const unlinkSync = (p: string) => {
-    memoryFs.delete(p);
+    if (!memoryFs.delete(p)) throw new Error(`ENOENT: ${p}`);
   };
-  const readdirSync = (dir: string) =>
-    [...memoryFs.keys()]
-      .filter((k) => k.startsWith(dir + '/'))
-      .map((k) => k.slice(dir.length + 1));
+  const readdirSync = (dir: string, opts?: { withFileTypes?: boolean }) => {
+    const names = new Set<string>();
+    for (const key of [...memoryFs.keys(), ...dirs]) {
+      if (key.startsWith(dir + '/')) {
+        names.add(key.slice(dir.length + 1).split('/')[0]);
+      }
+    }
+    if (!opts?.withFileTypes) return [...names];
+    return [...names].map((name) => ({
+      name,
+      isDirectory: () =>
+        dirs.has(`${dir}/${name}`) ||
+        [...memoryFs.keys()].some((k) => k.startsWith(`${dir}/${name}/`)),
+    }));
+  };
 
   const api = {
     mkdirSync,
+    rmdirSync,
+    statSync,
+    rmSync,
     existsSync,
     writeFileSync,
     renameSync,
@@ -53,6 +90,11 @@ vi.mock('fs', () => {
   };
   return { ...api, default: api };
 });
+
+// Helper: clear the lock-dir registry between tests via rmSync on root paths.
+function seedFile(path: string, content = 'x'): void {
+  memoryFs.set(path, content);
+}
 
 describe('chunkedJobStore', () => {
   const jobId = '11111111-2222-3333-4444-555555555555';
@@ -181,6 +223,49 @@ describe('chunkedJobStore', () => {
 
     it('is a no-op when no jobs exist', () => {
       expect(markInterruptedJobsFailed()).toEqual([]);
+    });
+
+    it('removes the interrupted job’s chunk files and per-job dir', () => {
+      const chunkDir = `${os.tmpdir()}/chunked-transcription/${jobA}`;
+      const chunkPaths = [`${chunkDir}/audio_chunk_000.mp3`];
+      seedFile(chunkPaths[0]);
+      createJob(jobA, ownerId, 1, chunkPaths, 'pending.mp3');
+
+      markInterruptedJobsFailed();
+
+      // Status reconciled AND disk reclaimed — interrupted chunks can never
+      // be consumed by the (now dead) in-process pipeline.
+      expect(getJob(jobA)?.status).toBe('failed');
+      expect(memoryFs.has(chunkPaths[0])).toBe(false);
+    });
+  });
+
+  describe('sweepOrphanedChunkDirs', () => {
+    const activeJob = '11111111-1111-1111-1111-111111111111';
+    const doneJob = '22222222-2222-2222-2222-222222222222';
+
+    it('removes dirs without a live job record, keeps active ones', () => {
+      const root = `${os.tmpdir()}/chunked-transcription`;
+      seedFile(`${root}/${activeJob}/a_chunk_000.mp3`);
+      seedFile(`${root}/${doneJob}/b_chunk_000.mp3`);
+      seedFile(`${root}/no-record-at-all/c_chunk_000.mp3`);
+
+      createJob(activeJob, ownerId, 1, [], 'active.mp3');
+      createJob(doneJob, ownerId, 1, [], 'done.mp3');
+      completeJob(doneJob, 'transcript');
+
+      const removed = sweepOrphanedChunkDirs();
+
+      expect(removed.sort()).toEqual([doneJob, 'no-record-at-all'].sort());
+      expect(memoryFs.has(`${root}/${activeJob}/a_chunk_000.mp3`)).toBe(true);
+      expect(memoryFs.has(`${root}/${doneJob}/b_chunk_000.mp3`)).toBe(false);
+      expect(memoryFs.has(`${root}/no-record-at-all/c_chunk_000.mp3`)).toBe(
+        false,
+      );
+    });
+
+    it('is a no-op when the chunk root does not exist', () => {
+      expect(sweepOrphanedChunkDirs()).toEqual([]);
     });
   });
 

--- a/__tests__/lib/services/transcription/chunkedTranscriptionService.test.ts
+++ b/__tests__/lib/services/transcription/chunkedTranscriptionService.test.ts
@@ -1,23 +1,65 @@
 import { ChunkedTranscriptionService } from '@/lib/services/transcription/chunkedTranscriptionService';
 
-import { describe, expect, it, vi } from 'vitest';
+import { TranscriptionError } from '@/types/transcription';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Programmable per-test Whisper behavior, shared by every constructed
+// service instance (the retry loop may rebuild the client mid-job).
+const whisperMocks = vi.hoisted(() => ({
+  transcribeChunk: vi.fn<(path: string) => Promise<string>>(),
+}));
 
 // Stub the Whisper client so instantiation doesn't require Azure env vars.
 vi.mock('@/lib/services/transcription/whisperTranscriptionService', () => ({
-  WhisperTranscriptionService: vi.fn().mockImplementation(function (this: any) {
-    this.transcribe = vi.fn();
+  WhisperTranscriptionService: vi.fn().mockImplementation(function (this: {
+    transcribeChunk: typeof whisperMocks.transcribeChunk;
+  }) {
+    this.transcribeChunk = whisperMocks.transcribeChunk;
   }),
 }));
 
-// `combineTranscripts` is private but it's the one piece of logic worth
-// pinning in isolation — the rest of the service talks to Whisper + fs
-// and is covered by integration-style tests elsewhere.
-type CombineAccess = {
+const storeMocks = vi.hoisted(() => ({
+  getJob: vi.fn(),
+  createJob: vi.fn(),
+  updateProgress: vi.fn(),
+  completeJob: vi.fn(),
+  failJob: vi.fn(),
+}));
+
+vi.mock('@/lib/services/transcription/chunkedJobStore', () => storeMocks);
+
+const splitterMocks = vi.hoisted(() => ({
+  cleanupChunks: vi.fn().mockResolvedValue(undefined),
+  isAudioSplittingAvailable: vi.fn().mockReturnValue(true),
+  splitAudioFile: vi.fn(),
+}));
+
+vi.mock('@/lib/utils/server/audio/audioSplitter', () => splitterMocks);
+
+// `combineTranscripts` and `processChunksAsync` are private; tests reach
+// them via a typed escape hatch (same pattern used elsewhere in the suite).
+type PrivateAccess = {
   combineTranscripts: (transcripts: string[], total: number) => string;
+  processChunksAsync: (
+    jobId: string,
+    chunkPaths: string[],
+    filename: string,
+  ) => Promise<void>;
 };
 
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function permanentError(message: string): TranscriptionError {
+  const err = new Error(message) as TranscriptionError;
+  err.errorClass = 'permanent';
+  return err;
+}
+
 describe('ChunkedTranscriptionService.combineTranscripts', () => {
-  const svc = new ChunkedTranscriptionService() as unknown as CombineAccess;
+  const svc = new ChunkedTranscriptionService() as unknown as PrivateAccess;
 
   it('returns the single transcript verbatim for a one-chunk job', () => {
     expect(svc.combineTranscripts(['hello world'], 1)).toBe('hello world');
@@ -35,5 +77,102 @@ describe('ChunkedTranscriptionService.combineTranscripts', () => {
     );
     expect(combined).toContain('[Chunk 1/3]\nhello');
     expect(combined).toContain('[Chunk 3/3]\nworld');
+  });
+});
+
+describe('ChunkedTranscriptionService.processChunksAsync (worker pool)', () => {
+  const jobId = '11111111-2222-3333-4444-555555555555';
+  const chunkPaths = ['/c/0.mp3', '/c/1.mp3', '/c/2.mp3', '/c/3.mp3'];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    splitterMocks.cleanupChunks.mockResolvedValue(undefined);
+    storeMocks.getJob.mockReturnValue({ jobId, status: 'processing' });
+  });
+
+  it('completes with chunks in playback order even when they finish out of order', async () => {
+    // Later chunks finish first — the pool must reorder by index.
+    const delays = [40, 25, 10, 5];
+    whisperMocks.transcribeChunk.mockImplementation(async (path: string) => {
+      const index = chunkPaths.indexOf(path);
+      await delay(delays[index]);
+      return `t${index}`;
+    });
+
+    const svc = new ChunkedTranscriptionService() as unknown as PrivateAccess;
+    await svc.processChunksAsync(jobId, chunkPaths, 'file.mp3');
+
+    expect(storeMocks.completeJob).toHaveBeenCalledTimes(1);
+    const transcript = storeMocks.completeJob.mock.calls[0][1] as string;
+    expect(transcript).toBe(
+      '[Chunk 1/4]\nt0\n\n[Chunk 2/4]\nt1\n\n[Chunk 3/4]\nt2\n\n[Chunk 4/4]\nt3',
+    );
+    expect(storeMocks.failJob).not.toHaveBeenCalled();
+    expect(splitterMocks.cleanupChunks).toHaveBeenCalledWith(chunkPaths);
+  });
+
+  it('starts no chunks when the job is already cancelled', async () => {
+    storeMocks.getJob.mockReturnValue({ jobId, status: 'cancelled' });
+
+    const svc = new ChunkedTranscriptionService() as unknown as PrivateAccess;
+    await svc.processChunksAsync(jobId, chunkPaths, 'file.mp3');
+
+    expect(whisperMocks.transcribeChunk).not.toHaveBeenCalled();
+    expect(storeMocks.completeJob).not.toHaveBeenCalled();
+    expect(storeMocks.failJob).not.toHaveBeenCalled();
+    // Chunks are still reclaimed.
+    expect(splitterMocks.cleanupChunks).toHaveBeenCalledWith(chunkPaths);
+  });
+
+  it('a permanent chunk failure fails the job and stops idle workers from claiming more chunks', async () => {
+    whisperMocks.transcribeChunk.mockImplementation(async (path: string) => {
+      const index = chunkPaths.indexOf(path);
+      if (index === 0) {
+        throw permanentError('chunk too large');
+      }
+      await delay(30);
+      return `t${index}`;
+    });
+
+    const svc = new ChunkedTranscriptionService() as unknown as PrivateAccess;
+    await expect(
+      svc.processChunksAsync(jobId, chunkPaths, 'file.mp3'),
+    ).rejects.toThrow('chunk too large');
+
+    expect(storeMocks.failJob).toHaveBeenCalledWith(
+      jobId,
+      'chunk too large',
+      'permanent',
+    );
+    expect(storeMocks.completeJob).not.toHaveBeenCalled();
+    // Default concurrency is 3: chunks 0–2 were claimed before the failure,
+    // but chunk 3 must never start once the abort flag is set.
+    expect(whisperMocks.transcribeChunk).toHaveBeenCalledTimes(3);
+    expect(splitterMocks.cleanupChunks).toHaveBeenCalledWith(chunkPaths);
+  });
+
+  it('a cancel mid-run stops remaining chunks without marking the job failed', async () => {
+    let completedFirst = false;
+    storeMocks.getJob.mockImplementation(() => ({
+      jobId,
+      // Cancelled as soon as the first chunk has gone through.
+      status: completedFirst ? 'cancelled' : 'processing',
+    }));
+    whisperMocks.transcribeChunk.mockImplementation(async (path: string) => {
+      await delay(10);
+      completedFirst = true;
+      return `t${chunkPaths.indexOf(path)}`;
+    });
+
+    const svc = new ChunkedTranscriptionService() as unknown as PrivateAccess;
+    await svc.processChunksAsync(jobId, chunkPaths, 'file.mp3');
+
+    expect(storeMocks.completeJob).not.toHaveBeenCalled();
+    expect(storeMocks.failJob).not.toHaveBeenCalled();
+    // The first wave (3 workers) ran; nothing was claimed after the cancel.
+    expect(whisperMocks.transcribeChunk.mock.calls.length).toBeLessThanOrEqual(
+      3,
+    );
+    expect(splitterMocks.cleanupChunks).toHaveBeenCalledWith(chunkPaths);
   });
 });

--- a/__tests__/lib/services/transcription/whisperTranscriptionService.test.ts
+++ b/__tests__/lib/services/transcription/whisperTranscriptionService.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Tests for WhisperTranscriptionService size-limit handling.
+ *
+ * Regression for issue #57: oversized inputs were thrown as untagged Errors
+ * (errorClass 'unknown'), so chunkedTranscriptionService retried them 3x even
+ * though a file never shrinks between attempts. They must be 'permanent'.
+ */
+import { WhisperTranscriptionService } from '@/lib/services/transcription/whisperTranscriptionService';
+
+import { WHISPER_MAX_SIZE } from '@/lib/utils/app/const';
+
+import { TranscriptionError } from '@/types/transcription';
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+// Stub env so the constructor doesn't require real Azure configuration.
+vi.mock('@/config/environment', () => ({
+  env: {
+    OPENAI_API_KEY: 'test-key',
+    AZURE_OPENAI_ENDPOINT: 'https://example.openai.azure.com',
+    OPENAI_API_VERSION: '2024-06-01',
+  },
+}));
+
+describe('WhisperTranscriptionService size limit', () => {
+  let workDir: string;
+  let oversizedPath: string;
+
+  beforeAll(async () => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'whisper-size-test-'));
+    oversizedPath = path.join(workDir, 'oversized.mp3');
+    // Sparse file just over the limit — instant to create, no real disk use.
+    const handle = await fs.promises.open(oversizedPath, 'w');
+    await handle.truncate(WHISPER_MAX_SIZE + 1);
+    await handle.close();
+  });
+
+  afterAll(() => {
+    fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it('rejects oversized files with a permanent errorClass (no futile retries)', async () => {
+    const service = new WhisperTranscriptionService();
+
+    let thrown: TranscriptionError | undefined;
+    try {
+      await service.transcribe(oversizedPath);
+    } catch (error) {
+      thrown = error as TranscriptionError;
+    }
+
+    expect(thrown).toBeDefined();
+    expect(thrown!.errorClass).toBe('permanent');
+    expect(thrown!.message).toContain('exceeds the maximum limit');
+  });
+});

--- a/__tests__/lib/services/transcription/whisperTranscriptionService.test.ts
+++ b/__tests__/lib/services/transcription/whisperTranscriptionService.test.ts
@@ -56,4 +56,28 @@ describe('WhisperTranscriptionService size limit', () => {
     expect(thrown!.errorClass).toBe('permanent');
     expect(thrown!.message).toContain('exceeds the maximum limit');
   });
+
+  // `transcribeSegment` is private, but it owns the size check the chunked
+  // retry loop actually hits — transcribe() rejects first on whole files, so
+  // the test above never reaches it. Same private-access pattern as
+  // chunkedTranscriptionService.test.ts.
+  type SegmentAccess = {
+    transcribeSegment: (segmentPath: string) => Promise<string>;
+  };
+
+  it('tags the segment-level size check as permanent (chunked retry path)', async () => {
+    const service =
+      new WhisperTranscriptionService() as unknown as SegmentAccess;
+
+    let thrown: TranscriptionError | undefined;
+    try {
+      await service.transcribeSegment(oversizedPath);
+    } catch (error) {
+      thrown = error as TranscriptionError;
+    }
+
+    expect(thrown).toBeDefined();
+    expect(thrown!.errorClass).toBe('permanent');
+    expect(thrown!.message).toContain('transcription limit');
+  });
 });

--- a/__tests__/lib/services/transcription/whisperTranscriptionService.test.ts
+++ b/__tests__/lib/services/transcription/whisperTranscriptionService.test.ts
@@ -57,21 +57,16 @@ describe('WhisperTranscriptionService size limit', () => {
     expect(thrown!.message).toContain('exceeds the maximum limit');
   });
 
-  // `transcribeSegment` is private, but it owns the size check the chunked
-  // retry loop actually hits — transcribe() rejects first on whole files, so
-  // the test above never reaches it. Same private-access pattern as
-  // chunkedTranscriptionService.test.ts.
-  type SegmentAccess = {
-    transcribeSegment: (segmentPath: string) => Promise<string>;
-  };
-
-  it('tags the segment-level size check as permanent (chunked retry path)', async () => {
-    const service =
-      new WhisperTranscriptionService() as unknown as SegmentAccess;
+  // transcribeChunk is the chunked pipeline's entry point. Its size check
+  // carries chunk-appropriate wording — the user uploaded a whole recording,
+  // not this chunk, so transcribe()'s "please upload a shorter audio file"
+  // message would mislead.
+  it('tags the chunk-level size check as permanent (chunked retry path)', async () => {
+    const service = new WhisperTranscriptionService();
 
     let thrown: TranscriptionError | undefined;
     try {
-      await service.transcribeSegment(oversizedPath);
+      await service.transcribeChunk(oversizedPath);
     } catch (error) {
       thrown = error as TranscriptionError;
     }

--- a/__tests__/lib/utils/server/audio/audioSplitter.test.ts
+++ b/__tests__/lib/utils/server/audio/audioSplitter.test.ts
@@ -16,6 +16,7 @@ import {
 } from '@/lib/utils/server/audio/audioSplitter';
 
 import { execFileSync } from 'child_process';
+import { randomUUID } from 'crypto';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -37,6 +38,17 @@ function resolveFfmpegBinary(): string | null {
 
 const ffmpegBinary = resolveFfmpegBinary();
 const canRun = ffmpegBinary !== null && isAudioSplittingAvailable();
+
+// On CI the suite below must actually run — a silent environment skip would
+// leave the chunk-sizing regression unprotected while `npm test` stays green.
+// ffmpeg comes from ffmpeg-static and ffprobe from ffprobe-static, so a
+// failure here means dependency installation broke, not a missing system tool.
+it.runIf(process.env.CI)(
+  'CI provides ffmpeg + ffprobe (regression suite must not skip)',
+  () => {
+    expect(canRun).toBe(true);
+  },
+);
 
 describe.skipIf(!canRun)('splitAudioFile (real ffmpeg)', () => {
   let workDir: string;
@@ -78,7 +90,9 @@ describe.skipIf(!canRun)('splitAudioFile (real ffmpeg)', () => {
     const result = await splitAudioFile(fixturePath, {
       targetChunkSizeBytes: TARGET_CHUNK_BYTES,
       outputFormat: 'mp3',
-      jobId: 'audio-splitter-test',
+      // Unique per run: a fixed id would reuse the same tmp dir, and chunks
+      // left by a crashed earlier run match the same filename pattern.
+      jobId: `audio-splitter-test-${randomUUID()}`,
     });
     chunkPaths = result.chunkPaths;
 
@@ -92,6 +106,17 @@ describe.skipIf(!canRun)('splitAudioFile (real ffmpeg)', () => {
       const { size } = fs.statSync(chunkPath);
       expect(size).toBeLessThanOrEqual(TARGET_CHUNK_BYTES * 1.25);
     }
+
+    // The chunk bitrate is clamped to the input's: re-encoding 32 kbps audio
+    // must not balloon total output to ~4x the source (the 128 kbps ceiling
+    // would). Allow 2x for bitrate-step rounding and container overhead.
+    const totalChunkBytes = result.chunkPaths.reduce(
+      (sum, chunkPath) => sum + fs.statSync(chunkPath).size,
+      0,
+    );
+    expect(totalChunkBytes).toBeLessThanOrEqual(
+      fs.statSync(fixturePath).size * 2,
+    );
 
     // Chunks must come back in playback order for transcript assembly.
     expect(result.chunkPaths).toEqual([...result.chunkPaths].sort());

--- a/__tests__/lib/utils/server/audio/audioSplitter.test.ts
+++ b/__tests__/lib/utils/server/audio/audioSplitter.test.ts
@@ -121,4 +121,37 @@ describe.skipIf(!canRun)('splitAudioFile (real ffmpeg)', () => {
     // Chunks must come back in playback order for transcript assembly.
     expect(result.chunkPaths).toEqual([...result.chunkPaths].sort());
   }, 120_000);
+
+  it('copies a within-target file into the per-job dir instead of returning the input', async () => {
+    // Callers treat every returned chunkPath as disposable (cleanupChunks
+    // deletes them) — handing back the caller's input file would let that
+    // cleanup destroy it.
+    const result = await splitAudioFile(fixturePath, {
+      // Fixture is ~2.4MB; a 5MB target means "no split needed".
+      targetChunkSizeBytes: 5 * 1024 * 1024,
+      outputFormat: 'mp3',
+      jobId: `audio-splitter-test-${randomUUID()}`,
+    });
+
+    expect(result.chunkCount).toBe(1);
+    expect(result.chunkPaths[0]).not.toBe(fixturePath);
+    expect(fs.existsSync(result.chunkPaths[0])).toBe(true);
+    // The copy is byte-identical (no re-encode for a file already in budget).
+    expect(fs.statSync(result.chunkPaths[0]).size).toBe(
+      fs.statSync(fixturePath).size,
+    );
+
+    // Deleting the "chunk" must leave the caller's input intact.
+    fs.rmSync(path.dirname(result.chunkPaths[0]), {
+      recursive: true,
+      force: true,
+    });
+    expect(fs.existsSync(fixturePath)).toBe(true);
+  }, 60_000);
+
+  it('rejects path-unsafe jobIds before touching the filesystem', async () => {
+    await expect(
+      splitAudioFile(fixturePath, { jobId: '../escape' }),
+    ).rejects.toThrow(/invalid jobid/i);
+  });
 });

--- a/__tests__/lib/utils/server/audio/audioSplitter.test.ts
+++ b/__tests__/lib/utils/server/audio/audioSplitter.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Integration tests for splitAudioFile using the real FFmpeg binary.
+ *
+ * Regression for issue #57: chunk duration was computed from the INPUT
+ * file's bitrate while chunks are re-encoded to mp3 at 128 kbps, so any
+ * low-bitrate input (e.g. an iPhone Voice Memo at ~64 kbps AAC) produced
+ * chunks far larger than intended — large enough to blow the 25MB Whisper
+ * limit and fail the whole transcription job, deterministically per file.
+ *
+ * The fixture reproduces that shape at small scale: a 32 kbps AAC mono
+ * file split with a 1MB target must not yield chunks ~4x the target.
+ */
+import {
+  isAudioSplittingAvailable,
+  splitAudioFile,
+} from '@/lib/utils/server/audio/audioSplitter';
+
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const FIXTURE_DURATION_SECS = 600;
+const TARGET_CHUNK_BYTES = 1024 * 1024; // 1MB target, scaled-down from prod's 20MB
+
+function resolveFfmpegBinary(): string | null {
+  const candidates = [
+    process.env.FFMPEG_BIN,
+    path.join(process.cwd(), 'node_modules', 'ffmpeg-static', 'ffmpeg'),
+  ];
+  for (const candidate of candidates) {
+    if (candidate && fs.existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+const ffmpegBinary = resolveFfmpegBinary();
+const canRun = ffmpegBinary !== null && isAudioSplittingAvailable();
+
+describe.skipIf(!canRun)('splitAudioFile (real ffmpeg)', () => {
+  let workDir: string;
+  let fixturePath: string;
+  let chunkPaths: string[] = [];
+
+  beforeAll(() => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'audio-splitter-test-'));
+    fixturePath = path.join(workDir, 'low-bitrate-voice-memo.m4a');
+
+    // 600s of sine at 32 kbps AAC mono ≈ 2.4MB — same low-bitrate shape as
+    // an iPhone Voice Memo, cheap enough to encode at test time.
+    execFileSync(ffmpegBinary!, [
+      '-f',
+      'lavfi',
+      '-i',
+      'sine=frequency=440:sample_rate=44100',
+      '-t',
+      String(FIXTURE_DURATION_SECS),
+      '-c:a',
+      'aac',
+      '-b:a',
+      '32k',
+      '-ac',
+      '1',
+      '-y',
+      fixturePath,
+    ]);
+  }, 60_000);
+
+  afterAll(() => {
+    fs.rmSync(workDir, { recursive: true, force: true });
+    for (const chunkPath of chunkPaths) {
+      fs.rmSync(path.dirname(chunkPath), { recursive: true, force: true });
+    }
+  });
+
+  it('keeps re-encoded chunks near the target size for low-bitrate input', async () => {
+    const result = await splitAudioFile(fixturePath, {
+      targetChunkSizeBytes: TARGET_CHUNK_BYTES,
+      outputFormat: 'mp3',
+      jobId: 'audio-splitter-test',
+    });
+    chunkPaths = result.chunkPaths;
+
+    expect(result.chunkCount).toBeGreaterThan(1);
+    expect(result.chunkPaths).toHaveLength(result.chunkCount);
+    expect(result.totalDurationSecs).toBeGreaterThan(FIXTURE_DURATION_SECS - 5);
+
+    // The whole point: no chunk may meaningfully exceed the target. The
+    // pre-fix behavior produced chunks at 128kbps/32kbps = 4x the target.
+    for (const chunkPath of result.chunkPaths) {
+      const { size } = fs.statSync(chunkPath);
+      expect(size).toBeLessThanOrEqual(TARGET_CHUNK_BYTES * 1.25);
+    }
+
+    // Chunks must come back in playback order for transcript assembly.
+    expect(result.chunkPaths).toEqual([...result.chunkPaths].sort());
+  }, 120_000);
+});

--- a/app/api/file/[id]/transcribe/route.ts
+++ b/app/api/file/[id]/transcribe/route.ts
@@ -56,8 +56,6 @@ export async function GET(
     );
   }
 
-  let transcript: string | undefined;
-
   try {
     const userId = getUserIdFromSession(session);
     const blobStorageClient = createBlobStorageClient(session);
@@ -91,6 +89,7 @@ export async function GET(
     if (serviceType === 'whisper') {
       // Synchronous transcription for small files (≤25MB)
       const tmpFilePath = join(tmpdir(), `${randomUUID()}_${id}`);
+      let transcript: string;
       try {
         await withAzureRetry(
           () => blockBlobClient.downloadToFile(tmpFilePath),
@@ -172,15 +171,6 @@ export async function GET(
     }
   } catch (error) {
     console.error('Error during transcription:', error);
-
-    // If we have a partial transcript (unlikely), return it
-    if (transcript) {
-      const response: TranscriptionResponse = {
-        async: false,
-        transcript,
-      };
-      return NextResponse.json(response);
-    }
 
     return NextResponse.json(
       {

--- a/app/api/file/[id]/transcribe/route.ts
+++ b/app/api/file/[id]/transcribe/route.ts
@@ -11,6 +11,7 @@ import { Session } from 'next-auth';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { createBlobStorageClient } from '@/lib/services/blobStorageFactory';
+import { recordBatchJobOwner } from '@/lib/services/transcription/batchJobRegistry';
 import { BatchTranscriptionService } from '@/lib/services/transcription/batchTranscriptionService';
 import { TranscriptionServiceFactory } from '@/lib/services/transcriptionService';
 
@@ -155,6 +156,10 @@ export async function GET(
         () => batchService.submitTranscription(sasUrl),
         { label: 'submitTranscription' },
       );
+
+      // Record ownership so the status/cleanup routes can verify that only
+      // the submitting user polls or deletes this job.
+      recordBatchJobOwner(jobId, userId);
 
       // Note: We don't delete the blob yet - it will be deleted after
       // the batch job completes and the transcript is retrieved

--- a/app/api/transcription/cleanup/route.ts
+++ b/app/api/transcription/cleanup/route.ts
@@ -9,6 +9,10 @@
  */
 import { NextRequest } from 'next/server';
 
+import {
+  deleteBatchJobRecord,
+  userOwnsBatchJob,
+} from '@/lib/services/transcription/batchJobRegistry';
 import { BatchTranscriptionService } from '@/lib/services/transcription/batchTranscriptionService';
 import {
   JOB_ID_REGEX,
@@ -113,20 +117,24 @@ export async function POST(request: NextRequest) {
 
     try {
       const batchService = new BatchTranscriptionService();
-      if (batchService.isConfigured()) {
+      if (ownedChunkedJob) {
+        // Chunked jobs have no remote batch record to delete; the chunk
+        // cleanup above is the whole job-side cleanup.
+        results.jobDeleted = true;
+      } else if (!userOwnsBatchJob(jobId, session.user.id)) {
+        // Unknown or not-owned batch job — same message for both so jobIds
+        // can't be enumerated, and no Azure call is made on the caller's
+        // behalf.
+        results.errors?.push('Transcription job not found');
+      } else if (batchService.isConfigured()) {
         await batchService.deleteTranscription(jobId);
+        deleteBatchJobRecord(jobId);
         results.jobDeleted = true;
         console.log(
           `[TranscriptionCleanup] Deleted transcription job: ${sanitizeForLog(jobId)}`,
         );
       } else {
-        // For chunked jobs there's no remote batch service to call; treat
-        // chunk cleanup above as the successful path.
-        if (ownedChunkedJob) {
-          results.jobDeleted = true;
-        } else {
-          results.errors?.push('Batch transcription service not configured');
-        }
+        results.errors?.push('Batch transcription service not configured');
       }
     } catch (error) {
       const errorMessage =

--- a/app/api/transcription/content/[jobId]/route.ts
+++ b/app/api/transcription/content/[jobId]/route.ts
@@ -9,8 +9,11 @@
  */
 import { NextRequest } from 'next/server';
 
+import { JOB_ID_REGEX } from '@/lib/services/transcription/chunkedJobStore';
+
 import { getEnvVariable } from '@/lib/utils/app/env';
 import {
+  badRequestResponse,
   errorResponse,
   notFoundResponse,
   successResponse,
@@ -36,6 +39,13 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
   if (!jobId) {
     return notFoundResponse('Job ID is required');
+  }
+
+  // Route params arrive URL-decoded, so without this check a crafted jobId
+  // (e.g. containing `../`) would be interpolated straight into the blob
+  // path below. Same validation as the store/cleanup/status routes.
+  if (!JOB_ID_REGEX.test(jobId)) {
+    return badRequestResponse('Invalid jobId format', 'INVALID_JOB_ID');
   }
 
   try {

--- a/app/api/transcription/queue/route.ts
+++ b/app/api/transcription/queue/route.ts
@@ -5,7 +5,7 @@ import { AzureBlobStorage } from '@/lib/utils/server/blob/blob';
 
 import { auth } from '@/auth';
 import { env } from '@/config/environment';
-import { DequeuedMessageItem } from '@azure/storage-queue';
+import { DequeuedMessageItem, QueueClient } from '@azure/storage-queue';
 import { v4 as uuidv4 } from 'uuid';
 
 // Allowed queue categories for security
@@ -17,9 +17,114 @@ const MAX_PEEK_MESSAGES = 32;
 const MAX_RECEIVE_MESSAGES = 32;
 const MAX_PAGINATION_ATTEMPTS = 100; // Prevent infinite loops (32 * 100 = 3200 max messages)
 
+/** Parsed shape of the queue messages this route writes. */
+interface QueueMessageContent {
+  messageId?: string;
+  userId?: string;
+  message?: unknown;
+}
+
+/**
+ * Parses a queue message's base64 JSON envelope. Returns null for messages
+ * this route didn't write (foreign producers, corrupt payloads) so callers
+ * skip them instead of throwing a 500 for the whole request.
+ */
+function tryParseMessage(messageText: string): QueueMessageContent | null {
+  try {
+    const parsed = JSON.parse(base64Decode(messageText));
+    return typeof parsed === 'object' && parsed !== null
+      ? (parsed as QueueMessageContent)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Validates the category param and resolves it to a queue name. */
+function resolveQueueName(category: unknown): QueueCategory | null {
+  if (typeof category !== 'string') return null;
+  const queueName = category.toLowerCase() as QueueCategory;
+  return ALLOWED_QUEUE_CATEGORIES.includes(queueName) ? queueName : null;
+}
+
+/** Result of searching the queue for a specific message via receive. */
+interface ReceiveSearchResult {
+  /** The dequeued target message (invisible to other consumers), or null. */
+  target: DequeuedMessageItem | null;
+  /** True when the message was found but belongs to another user. */
+  forbidden: boolean;
+  /** How many messages were scanned before concluding. */
+  scanned: number;
+}
+
+/**
+ * Finds a message by envelope messageId using receiveMessages pagination
+ * (receive, unlike peek, does advance through the queue).
+ *
+ * receiveMessages makes every returned message invisible for the visibility
+ * timeout, so every message we are NOT acting on is restored to visible
+ * before this returns — otherwise a deep scan would stall real consumers
+ * for the full timeout. A found-but-foreign target is restored too.
+ */
+async function findQueuedMessage(
+  queueClient: QueueClient,
+  messageId: string,
+  userId: string | undefined,
+): Promise<ReceiveSearchResult> {
+  let target: DequeuedMessageItem | null = null;
+  let forbidden = false;
+  let scanned = 0;
+  const toRestore: DequeuedMessageItem[] = [];
+
+  try {
+    for (let attempt = 0; attempt < MAX_PAGINATION_ATTEMPTS; attempt++) {
+      const receiveResponse = await queueClient.receiveMessages({
+        numberOfMessages: MAX_RECEIVE_MESSAGES,
+        visibilityTimeout: 30,
+      });
+      const messages = receiveResponse.receivedMessageItems;
+      if (messages.length === 0) break;
+
+      for (const message of messages) {
+        scanned++;
+        const content = tryParseMessage(message.messageText);
+        if (!target && !forbidden && content?.messageId === messageId) {
+          if (content.userId !== userId) {
+            forbidden = true;
+            toRestore.push(message);
+          } else {
+            target = message;
+          }
+        } else {
+          toRestore.push(message);
+        }
+      }
+
+      if (target || forbidden) break;
+      if (messages.length < MAX_RECEIVE_MESSAGES) break;
+    }
+  } finally {
+    const outcomes = await Promise.allSettled(
+      toRestore.map((m) =>
+        queueClient.updateMessage(m.messageId, m.popReceipt, m.messageText, 0),
+      ),
+    );
+    const failed = outcomes.filter((o) => o.status === 'rejected').length;
+    if (failed > 0) {
+      console.warn(
+        `[TranscriptionQueue] Failed to restore visibility for ${failed}/${toRestore.length} scanned message(s); they become visible again when the 30s timeout lapses`,
+      );
+    }
+  }
+
+  return { target, forbidden, scanned };
+}
+
 async function initializeBlobStorage(req: NextRequest) {
   const session: Session | null = await auth();
-  if (!session) throw new Error('Failed to pull session!');
+  // Message must be exactly 'Unauthorized' — the route catch blocks map it
+  // to a 401 (anything else becomes a 500).
+  if (!session) throw new Error('Unauthorized');
 
   const user = session.user;
 
@@ -61,11 +166,8 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     }
 
     // Validate queue category against whitelist
-    if (
-      !ALLOWED_QUEUE_CATEGORIES.includes(
-        category.toLowerCase() as QueueCategory,
-      )
-    ) {
+    const queueName = resolveQueueName(category);
+    if (!queueName) {
       return NextResponse.json(
         {
           error: 'Invalid queue category',
@@ -76,63 +178,44 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     }
 
     const { azureBlobStorage, user } = await initializeBlobStorage(req);
-    const queueName = category.toLowerCase();
     const queueClient = azureBlobStorage.getQueueClient(queueName);
 
-    // Peeking messages with pagination to handle queues with >32 messages
+    // Azure's peekMessages has no pagination cursor — repeated peeks return
+    // the same front-of-queue messages, so "paging" with peek just re-reads
+    // the first page forever. Search the deepest single peek the API allows
+    // and say so explicitly when the message is beyond it.
+    const peekedMessages = await queueClient.peekMessages({
+      numberOfMessages: MAX_PEEK_MESSAGES,
+    });
+    const messages = peekedMessages.peekedMessageItems;
+
     let position = -1;
-    let originalMessage: any = null;
-    let totalPeeked = 0;
+    let originalMessage: QueueMessageContent | null = null;
 
-    for (let attempt = 0; attempt < MAX_PAGINATION_ATTEMPTS; attempt++) {
-      const peekedMessages = await queueClient.peekMessages({
-        numberOfMessages: MAX_PEEK_MESSAGES,
-      });
+    for (let i = 0; i < messages.length; i++) {
+      const messageContent = tryParseMessage(messages[i].messageText);
+      if (!messageContent) continue;
 
-      const messages = peekedMessages.peekedMessageItems;
-
-      if (messages.length === 0) {
-        // No more messages in queue
-        break;
-      }
-
-      for (let i = 0; i < messages.length; i++) {
-        const message = messages[i];
-        const messageContent = JSON.parse(base64Decode(message.messageText));
-
-        if (messageContent.messageId === messageId) {
-          if (messageContent.userId !== user.id) {
-            return NextResponse.json(
-              {
-                message:
-                  'Forbidden: this message is not marked with your user identifier.',
-              },
-              { status: 403 },
-            );
-          }
-          position = totalPeeked + i + 1; // Positions start at 1
-          originalMessage = messageContent;
-          break;
+      if (messageContent.messageId === messageId) {
+        if (messageContent.userId !== user.id) {
+          return NextResponse.json(
+            {
+              message:
+                'Forbidden: this message is not marked with your user identifier.',
+            },
+            { status: 403 },
+          );
         }
-      }
-
-      if (position !== -1) {
-        // Found the message
-        break;
-      }
-
-      totalPeeked += messages.length;
-
-      // If we got fewer than MAX_PEEK_MESSAGES, we've reached the end
-      if (messages.length < MAX_PEEK_MESSAGES) {
+        position = i + 1; // Positions start at 1
+        originalMessage = messageContent;
         break;
       }
     }
 
-    if (position === -1) {
+    if (position === -1 || !originalMessage) {
       return NextResponse.json(
         {
-          error: `Message not found in queue (searched ${totalPeeked} messages)`,
+          error: `Message not found among the first ${MAX_PEEK_MESSAGES} queued messages`,
         },
         { status: 404 },
       );
@@ -176,8 +259,10 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       );
     }
 
-    // Validate queue category against whitelist
-    if (!ALLOWED_QUEUE_CATEGORIES.includes(category.toLowerCase())) {
+    // Validate queue category against whitelist (also rejects non-string
+    // payloads, which previously threw on .toLowerCase() and surfaced as 500)
+    const queueName = resolveQueueName(category);
+    if (!queueName) {
       return NextResponse.json(
         {
           error: 'Invalid queue category',
@@ -186,8 +271,6 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         { status: 400 },
       );
     }
-
-    const queueName = category.toLowerCase();
 
     // Ensure the queue exists
     const queueClient = azureBlobStorage.getQueueClient(queueName);
@@ -254,11 +337,8 @@ export async function PATCH(req: NextRequest): Promise<NextResponse> {
     }
 
     // Validate queue category against whitelist
-    if (
-      !ALLOWED_QUEUE_CATEGORIES.includes(
-        category.toLowerCase() as QueueCategory,
-      )
-    ) {
+    const queueName = resolveQueueName(category);
+    if (!queueName) {
       return NextResponse.json(
         {
           error: 'Invalid queue category',
@@ -268,63 +348,31 @@ export async function PATCH(req: NextRequest): Promise<NextResponse> {
       );
     }
 
-    const queueName = category.toLowerCase();
     const queueClient = azureBlobStorage.getQueueClient(queueName);
 
-    // Receive messages with pagination to handle queues with >32 messages
-    let targetMessage: DequeuedMessageItem | null = null;
-    let totalReceived = 0;
+    // Receive messages with pagination; every non-target message scanned is
+    // restored to visible by findQueuedMessage.
+    const {
+      target: targetMessage,
+      forbidden,
+      scanned,
+    } = await findQueuedMessage(queueClient, messageId, user.id);
 
-    for (let attempt = 0; attempt < MAX_PAGINATION_ATTEMPTS; attempt++) {
-      const receiveResponse = await queueClient.receiveMessages({
-        numberOfMessages: MAX_RECEIVE_MESSAGES,
-        visibilityTimeout: 30,
-      });
-
-      const messages = receiveResponse.receivedMessageItems;
-
-      if (messages.length === 0) {
-        // No more messages in queue
-        break;
-      }
-
-      for (const message of messages) {
-        const messageContent = JSON.parse(base64Decode(message.messageText));
-
-        if (messageContent.messageId === messageId) {
-          // Check if the message belongs to the user
-          if (messageContent.userId !== user.id) {
-            return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-          }
-          targetMessage = message;
-          break;
-        }
-      }
-
-      if (targetMessage) {
-        // Found the message
-        break;
-      }
-
-      totalReceived += messages.length;
-
-      // If we got fewer than MAX_RECEIVE_MESSAGES, we've reached the end
-      if (messages.length < MAX_RECEIVE_MESSAGES) {
-        break;
-      }
+    if (forbidden) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 
     if (!targetMessage) {
       return NextResponse.json(
         {
-          error: `Message not found in queue (searched ${totalReceived} messages)`,
+          error: `Message not found in queue (searched ${scanned} messages)`,
         },
         { status: 404 },
       );
     }
 
     const updatedMessageContent = {
-      ...JSON.parse(base64Decode(targetMessage.messageText)),
+      ...(tryParseMessage(targetMessage.messageText) ?? {}),
       message: newMessageContent,
     };
 
@@ -377,11 +425,8 @@ export async function DELETE(req: NextRequest): Promise<NextResponse> {
     }
 
     // Validate queue category against whitelist
-    if (
-      !ALLOWED_QUEUE_CATEGORIES.includes(
-        category.toLowerCase() as QueueCategory,
-      )
-    ) {
+    const queueName = resolveQueueName(category);
+    if (!queueName) {
       return NextResponse.json(
         {
           error: 'Invalid queue category',
@@ -392,57 +437,24 @@ export async function DELETE(req: NextRequest): Promise<NextResponse> {
     }
 
     const { azureBlobStorage, user } = await initializeBlobStorage(req);
-
-    const queueName = category.toLowerCase();
     const queueClient = azureBlobStorage.getQueueClient(queueName);
 
-    // Receive messages with pagination to handle queues with >32 messages
-    let targetMessage: DequeuedMessageItem | null = null;
-    let totalReceived = 0;
+    // Receive messages with pagination; every non-target message scanned is
+    // restored to visible by findQueuedMessage.
+    const {
+      target: targetMessage,
+      forbidden,
+      scanned,
+    } = await findQueuedMessage(queueClient, messageId, user.id);
 
-    for (let attempt = 0; attempt < MAX_PAGINATION_ATTEMPTS; attempt++) {
-      const receiveResponse = await queueClient.receiveMessages({
-        numberOfMessages: MAX_RECEIVE_MESSAGES,
-        visibilityTimeout: 30,
-      });
-
-      const messages = receiveResponse.receivedMessageItems;
-
-      if (messages.length === 0) {
-        // No more messages in queue
-        break;
-      }
-
-      for (const message of messages) {
-        const messageContent = JSON.parse(base64Decode(message.messageText));
-
-        if (messageContent.messageId === messageId) {
-          // Check if the message belongs to the user
-          if (messageContent.userId !== user.id) {
-            return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-          }
-          targetMessage = message;
-          break;
-        }
-      }
-
-      if (targetMessage) {
-        // Found the message
-        break;
-      }
-
-      totalReceived += messages.length;
-
-      // If we got fewer than MAX_RECEIVE_MESSAGES, we've reached the end
-      if (messages.length < MAX_RECEIVE_MESSAGES) {
-        break;
-      }
+    if (forbidden) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 
     if (!targetMessage) {
       return NextResponse.json(
         {
-          error: `Message not found in queue (searched ${totalReceived} messages)`,
+          error: `Message not found in queue (searched ${scanned} messages)`,
         },
         { status: 404 },
       );

--- a/app/api/transcription/status/[jobId]/route.ts
+++ b/app/api/transcription/status/[jobId]/route.ts
@@ -12,6 +12,7 @@
  */
 import { NextRequest, NextResponse } from 'next/server';
 
+import { userOwnsBatchJob } from '@/lib/services/transcription/batchJobRegistry';
 import { BatchTranscriptionService } from '@/lib/services/transcription/batchTranscriptionService';
 import {
   JOB_CANCELLED_MESSAGE,
@@ -107,6 +108,17 @@ export async function GET(
   // Check if service is configured
   if (!batchService.isConfigured()) {
     // If neither chunked nor batch job found, return not found
+    return errorResponse(
+      'Transcription job not found',
+      404,
+      `Job ${jobId} not found in chunked or batch systems`,
+    );
+  }
+
+  // Batch jobs live in Azure with no per-user scoping of their own; enforce
+  // the locally recorded ownership before touching the Azure API. Denial is
+  // an indistinguishable 404 so jobIds can't be enumerated.
+  if (!userOwnsBatchJob(jobId, session.user.id)) {
     return errorResponse(
       'Transcription job not found',
       404,

--- a/app/api/user/profile/route.ts
+++ b/app/api/user/profile/route.ts
@@ -1,3 +1,4 @@
+import { getToken } from 'next-auth/jwt';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { auth } from '@/auth';
@@ -16,8 +17,24 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    // Get refresh token from session (exposed via session callback in auth.ts)
-    if (!session.refreshToken) {
+    // Read the refresh token directly from the JWT (server-side only). It is
+    // deliberately not exposed on the session, so client code can never read
+    // it. getToken derives the cookie name + JWE salt from `secureCookie`, so
+    // we must match how the cookie was issued: prod (https) uses the
+    // __Secure- prefixed cookie, dev (http) uses the unprefixed one. Behind a
+    // TLS-terminating proxy the internal request can be http, so key off the
+    // configured auth URL rather than the request protocol.
+    const secureCookie =
+      (process.env.AUTH_URL || process.env.NEXTAUTH_URL || '').startsWith(
+        'https',
+      ) || process.env.NODE_ENV === 'production';
+    const token = await getToken({
+      req,
+      secret: process.env.NEXTAUTH_SECRET || process.env.AUTH_SECRET,
+      secureCookie,
+    });
+
+    if (!token?.refreshToken) {
       return NextResponse.json({ error: 'No refresh token' }, { status: 401 });
     }
 
@@ -33,7 +50,7 @@ export async function GET(req: NextRequest) {
             grant_type: 'refresh_token',
             client_id: env.AZURE_CLIENT_ID || '',
             client_secret: env.AZURE_CLIENT_SECRET || '',
-            refresh_token: session.refreshToken,
+            refresh_token: token.refreshToken,
             scope: 'openid User.Read User.ReadBasic.all offline_access',
           }).toString(),
         },

--- a/auth.ts
+++ b/auth.ts
@@ -17,7 +17,10 @@ declare module 'next-auth' {
 
   interface Session {
     error?: string;
-    refreshToken?: string;
+    // Note: the refresh token is intentionally NOT exposed on the Session.
+    // It stays in the JWT only (server-side) and is read via getToken() in
+    // routes that need it, so client code (useSession / /api/auth/session)
+    // can never read it.
   }
 }
 
@@ -246,7 +249,8 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
           region: userRegion,
         } as Session['user'],
         error: token.error,
-        refreshToken: token.refreshToken, // Expose refresh token for on-demand profile refresh if needed
+        // Refresh token is deliberately omitted here — it must not reach the
+        // client. Server-side consumers read it from the JWT via getToken().
         expires: session.expires,
       };
     },

--- a/client/hooks/chat/useChat.ts
+++ b/client/hooks/chat/useChat.ts
@@ -34,6 +34,7 @@ export function useChat() {
       isRetrying: s.isRetrying,
       retryWithFallback: s.retryWithFallback,
       originalModelId: s.originalModelId,
+      successfulFallbackModelId: s.successfulFallbackModelId,
       showModelSwitchPrompt: s.showModelSwitchPrompt,
       failedConversation: s.failedConversation,
       errorIsRecoverable: s.errorIsRecoverable,

--- a/client/stores/chatStore.ts
+++ b/client/stores/chatStore.ts
@@ -30,6 +30,7 @@ import { useSettingsStore } from './settingsStore';
 import { useUIStore } from './uiStore';
 
 import { ApiError, chatService } from '@/client/services';
+import { getFallbackModel } from '@/config/models';
 import { create } from 'zustand';
 
 interface ChatStore {
@@ -48,6 +49,12 @@ interface ChatStore {
   isRetrying: boolean;
   retryWithFallback: boolean;
   originalModelId: string | null;
+  /**
+   * The fallback-chain model that actually produced the successful retry —
+   * the switch prompt and acceptModelSwitch must reference this model, not
+   * the first entry of the chain, since the chain may have advanced.
+   */
+  successfulFallbackModelId: string | null;
   showModelSwitchPrompt: boolean;
   failedConversation: Conversation | null;
   failedSearchMode: SearchMode | undefined;
@@ -160,6 +167,7 @@ interface ChatStore {
   retryWithFallbackModel: (
     conversation: Conversation,
     searchMode?: SearchMode,
+    attemptedModelIds?: string[],
   ) => Promise<void>;
   dismissModelSwitchPrompt: () => void;
   acceptModelSwitch: (alwaysSwitch?: boolean) => void;
@@ -215,6 +223,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   isRetrying: false,
   retryWithFallback: false,
   originalModelId: null,
+  successfulFallbackModelId: null,
   showModelSwitchPrompt: false,
   failedConversation: null,
   failedSearchMode: undefined,
@@ -285,6 +294,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       isRetrying: false,
       retryWithFallback: false,
       originalModelId: null,
+      successfulFallbackModelId: null,
       showModelSwitchPrompt: false,
       failedConversation: null,
       failedSearchMode: undefined,
@@ -521,9 +531,12 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       console.warn(
         `[chatStore] Model "${conversation.model.id}" no longer exists, using fallback model`,
       );
-      // Try settings default, then global fallback
+      // Try settings default, then the fallback chain
       const fallbackId = settings.defaultModelId || fallbackModelID;
-      latestModelConfig = OpenAIModels[fallbackId];
+      latestModelConfig =
+        OpenAIModels[fallbackId] ??
+        getFallbackModel([conversation.model.id]) ??
+        undefined;
 
       if (!latestModelConfig) {
         throw new Error(

--- a/client/stores/chatStore.ts
+++ b/client/stores/chatStore.ts
@@ -896,10 +896,14 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   retryWithFallbackModel: async (
     conversation: Conversation,
     searchMode?: SearchMode,
+    attemptedModelIds: string[] = [conversation.model.id],
   ) => {
-    const fallbackModel = OpenAIModels[fallbackModelID];
+    const fallbackModel = getFallbackModel(attemptedModelIds);
     if (!fallbackModel) {
-      console.error('[chatStore] Fallback model not found:', fallbackModelID);
+      console.error(
+        '[chatStore] Fallback chain exhausted, attempted:',
+        attemptedModelIds,
+      );
       set({
         error: 'Failed to send message. Please try again.',
         isStreaming: false,
@@ -1053,6 +1057,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       set({
         isRetrying: false,
         retryWithFallback: true,
+        successfulFallbackModelId: fallbackModel.id,
         showModelSwitchPrompt: true,
         successfulRetryConversationId: conversation.id,
         failedConversation: null,
@@ -1069,6 +1074,31 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       // Clean up timeout
       if (showLoadingTimeout) {
         clearTimeout(showLoadingTimeout);
+      }
+
+      // User clicked stop mid-retry — don't continue the chain or show errors
+      if (retryError instanceof Error && retryError.name === 'AbortError') {
+        toast.dismiss(toastId);
+        get().clearStreamingState();
+        set({ isRetrying: false, error: null });
+        return;
+      }
+
+      // Try the next model in the fallback chain, unless this failure would
+      // hit every model the same way (4xx other than rate limiting)
+      const isNonRetryableClientError =
+        retryError instanceof ApiError &&
+        retryError.isClientError() &&
+        retryError.status !== 429;
+      const nextAttemptedIds = [...attemptedModelIds, fallbackModel.id];
+
+      if (!isNonRetryableClientError && getFallbackModel(nextAttemptedIds)) {
+        toast.dismiss(toastId);
+        return get().retryWithFallbackModel(
+          conversation,
+          searchMode,
+          nextAttemptedIds,
+        );
       }
 
       // Dismiss loading toast
@@ -1104,6 +1134,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     set({
       showModelSwitchPrompt: false,
       originalModelId: null,
+      successfulFallbackModelId: null,
       retryWithFallback: false,
       successfulRetryConversationId: null,
     });
@@ -1112,10 +1143,14 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   acceptModelSwitch: (alwaysSwitch?: boolean) => {
     const settings = useSettingsStore.getState();
     const conversationStore = useConversationStore.getState();
-    const { successfulRetryConversationId } = get();
+    const { successfulRetryConversationId, successfulFallbackModelId } = get();
+
+    // Switch to the chain model that actually produced the successful retry
+    const switchedModelId = (successfulFallbackModelId ||
+      fallbackModelID) as OpenAIModelID;
 
     // Set fallback as default model for new conversations
-    settings.setDefaultModelId(fallbackModelID);
+    settings.setDefaultModelId(switchedModelId);
 
     // If alwaysSwitch, persist auto-switch preference for future failures
     if (alwaysSwitch) {
@@ -1124,7 +1159,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
 
     // Update current conversation model using the stored ID
     if (successfulRetryConversationId) {
-      const fallbackModel = OpenAIModels[fallbackModelID];
+      const fallbackModel = OpenAIModels[switchedModelId];
       if (fallbackModel) {
         conversationStore.updateConversation(successfulRetryConversationId, {
           model: fallbackModel,
@@ -1135,6 +1170,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     set({
       showModelSwitchPrompt: false,
       originalModelId: null,
+      successfulFallbackModelId: null,
       retryWithFallback: false,
       successfulRetryConversationId: null,
     });

--- a/client/stores/chatStore.ts
+++ b/client/stores/chatStore.ts
@@ -533,16 +533,15 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       );
       // Try settings default, then the fallback chain
       const fallbackId = settings.defaultModelId || fallbackModelID;
-      latestModelConfig =
-        OpenAIModels[fallbackId] ??
-        getFallbackModel([conversation.model.id]) ??
-        undefined;
+      const rescuedModel =
+        OpenAIModels[fallbackId] ?? getFallbackModel([conversation.model.id]);
 
-      if (!latestModelConfig) {
+      if (!rescuedModel) {
         throw new Error(
           `No valid model available. Requested: ${conversation.model.id}, Fallback: ${fallbackId}`,
         );
       }
+      latestModelConfig = rescuedModel;
     }
 
     // For organization/custom agents, use the conversation model directly (it already has full config)
@@ -830,22 +829,30 @@ export const useChatStore = create<ChatStore>((set, get) => ({
       return;
     }
 
-    // Check if we should attempt auto-retry with fallback model
+    // Check if we should attempt auto-retry with a fallback model.
+    // Client errors (4xx) other than 429 would fail identically on any
+    // model — bad payload, auth, corrupted history — so don't fall back.
+    // 5xx, rate limits, and network errors are worth trying another model.
     const { isRetrying } = get();
-    const isAuthError = error instanceof ApiError && error.isAuthError();
+    const isNonRetryableClientError =
+      error instanceof ApiError &&
+      error.isClientError() &&
+      error.status !== 429;
     const isCustomAgent = conversation?.model?.id?.startsWith('custom-');
-    const isAlreadyOnFallback = conversation?.model?.id === fallbackModelID;
+    const nextFallbackModel = conversation
+      ? getFallbackModel([conversation.model.id])
+      : null;
     const canRetry =
-      !isAuthError &&
+      !isNonRetryableClientError &&
       !isCustomAgent &&
-      !isAlreadyOnFallback &&
       !isRetrying &&
-      conversation;
+      conversation &&
+      nextFallbackModel;
 
     if (canRetry) {
       console.log(
         '[chatStore] Attempting auto-retry with fallback model:',
-        fallbackModelID,
+        nextFallbackModel.id,
       );
       // Store failed conversation for regenerate button
       set({

--- a/client/stores/chatStore.ts
+++ b/client/stores/chatStore.ts
@@ -842,14 +842,14 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     const nextFallbackModel = conversation
       ? getFallbackModel([conversation.model.id])
       : null;
-    const canRetry =
+
+    if (
       !isNonRetryableClientError &&
       !isCustomAgent &&
       !isRetrying &&
       conversation &&
-      nextFallbackModel;
-
-    if (canRetry) {
+      nextFallbackModel
+    ) {
       console.log(
         '[chatStore] Attempting auto-retry with fallback model:',
         nextFallbackModel.id,

--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -114,6 +114,7 @@ export function Chat({
     isRetrying,
     showModelSwitchPrompt,
     originalModelId,
+    successfulFallbackModelId,
     dismissModelSwitchPrompt,
     acceptModelSwitch,
     errorIsRecoverable,
@@ -646,7 +647,13 @@ export function Chat({
               originalModelId ||
               'Unknown'
             }
-            fallbackModelName={OpenAIModels[fallbackModelID]?.name || 'GPT-4.1'}
+            fallbackModelName={
+              OpenAIModels[
+                (successfulFallbackModelId || fallbackModelID) as OpenAIModelID
+              ]?.name ||
+              successfulFallbackModelId ||
+              'GPT-4.1'
+            }
             onKeepOriginal={dismissModelSwitchPrompt}
             onSwitchModel={() => acceptModelSwitch(false)}
             onAlwaysSwitch={() => acceptModelSwitch(true)}

--- a/config/models.ts
+++ b/config/models.ts
@@ -1,14 +1,31 @@
 /**
  * Environment-specific model configurations
- * Defines default model and model availability per environment
+ * Defines default model, fallback chain, and model availability per environment
  */
+import { OpenAIModel, OpenAIModelID, OpenAIModels } from '@/types/openai';
 
 export type Environment = 'localhost' | 'dev' | 'prod';
 
 export interface EnvironmentConfig {
   defaultModel: string;
+  fallbackChain?: string[]; // Error-fallback order; defaults to DEFAULT_FALLBACK_CHAIN
   disabledModels?: string[]; // Models that should not be available in this environment
 }
+
+/**
+ * Ordered chain of models to fall back to when a chat request fails with a
+ * model-specific error. The default model comes first (most reliable), then
+ * progressively different models/providers so an outage affecting one
+ * deployment doesn't take out every fallback. Agent and non-streaming
+ * reasoning models are intentionally excluded — their behavior differs too
+ * much to substitute silently.
+ */
+const DEFAULT_FALLBACK_CHAIN: string[] = [
+  OpenAIModelID.GPT_5_2_CHAT,
+  OpenAIModelID.GPT_5_2,
+  OpenAIModelID.GPT_5_MINI,
+  OpenAIModelID.DEEPSEEK_V3_1,
+];
 
 const modelConfigs: Record<Environment, EnvironmentConfig> = {
   localhost: {
@@ -66,4 +83,34 @@ export function getDefaultModel(): string {
 export function isModelDisabled(modelId: string): boolean {
   const config = getModelConfig();
   return config.disabledModels?.includes(modelId) ?? false;
+}
+
+/**
+ * Gets the error-fallback chain for the current environment
+ */
+export function getFallbackChain(): string[] {
+  return getModelConfig().fallbackChain ?? DEFAULT_FALLBACK_CHAIN;
+}
+
+/**
+ * Returns the next model to fall back to after a model-specific failure.
+ *
+ * Walks the environment's fallback chain and returns the first model that
+ * exists, is enabled, and is not in `excludeModelIds` (the model that just
+ * failed plus any fallbacks already attempted). Returns null when the chain
+ * is exhausted — callers should surface the original error at that point.
+ */
+export function getFallbackModel(
+  excludeModelIds: string[],
+): OpenAIModel | null {
+  for (const modelId of getFallbackChain()) {
+    if (excludeModelIds.includes(modelId)) continue;
+    if (isModelDisabled(modelId)) continue;
+
+    const model = OpenAIModels[modelId as OpenAIModelID];
+    if (model && !model.isDisabled) {
+      return model;
+    }
+  }
+  return null;
 }

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -13,11 +13,14 @@ export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
     // Reconcile chunked transcription jobs that were mid-flight when the
     // previous process exited. Without this, clients polling such jobs see a
-    // permanent 404 with no indication the job was lost to a restart.
+    // permanent 404 with no indication the job was lost to a restart. Also
+    // reclaim disk: interrupted jobs' chunk files and any orphaned per-job
+    // chunk directories can never be consumed again.
     try {
-      const { markInterruptedJobsFailed } =
+      const { markInterruptedJobsFailed, sweepOrphanedChunkDirs } =
         await import('@/lib/services/transcription/chunkedJobStore');
       markInterruptedJobsFailed();
+      sweepOrphanedChunkDirs();
     } catch (err) {
       console.warn(
         '[Instrumentation] Could not reconcile interrupted transcription jobs:',

--- a/lib/services/chat/FileProcessingService.ts
+++ b/lib/services/chat/FileProcessingService.ts
@@ -7,6 +7,7 @@ import { getUserIdFromSession } from '@/lib/utils/app/user/session';
 import { BlobProperty } from '@/lib/utils/server/blob/blob';
 import { getCachedTextPath } from '@/lib/utils/server/file/textCacheUtils';
 
+import { randomUUID } from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import { performance } from 'perf_hooks';
@@ -199,6 +200,11 @@ export class FileProcessingService {
    * Generates a safe temporary file path using blob ID.
    * Includes sanitization to prevent path traversal attacks.
    *
+   * The path is unique per call (random prefix): blob IDs are content
+   * hashes, so two concurrent requests referencing the same file would
+   * otherwise share one temp path — and one request's cleanup would delete
+   * the file out from under the other mid-transcription.
+   *
    * @param fileUrl - The blob storage URL
    * @returns Tuple of [sanitizedBlobId, resolvedFilePath]
    * @throws Error if blobId is missing, contains unsafe characters, or results in path traversal
@@ -216,7 +222,7 @@ export class FileProcessingService {
       throw new Error('Invalid blob ID: contains unsafe characters');
     }
 
-    const filePath = path.join('/tmp', sanitized);
+    const filePath = path.join('/tmp', `${randomUUID()}_${sanitized}`);
 
     // Defense in depth: verify resolved path stays within /tmp/
     const resolved = path.resolve(filePath);

--- a/lib/services/chat/processors/FileProcessor.ts
+++ b/lib/services/chat/processors/FileProcessor.ts
@@ -75,6 +75,12 @@ export class FileProcessor extends BasePipelineStage {
         },
       },
       async (span) => {
+        // Every downloaded temp file is registered here the moment its path
+        // is reserved (before the download starts), so the finally below can
+        // clean up partial downloads too. Cleanup must not depend on the
+        // happy path: a single failing file used to skip cleanup entirely
+        // and strand multi-GB downloads in /tmp.
+        const tempFilePaths: string[] = [];
         try {
           const perfStart = performance.now();
           const lastMessage = context.messages[context.messages.length - 1];
@@ -160,6 +166,10 @@ export class FileProcessor extends BasePipelineStage {
               const [blobId, filePath] =
                 this.fileProcessingService.getTempFilePath(file.url);
               const filename = file.originalFilename || blobId;
+
+              // Register before downloading so a failed/partial download is
+              // still cleaned up by the finally block.
+              tempFilePaths.push(filePath);
 
               console.log(
                 `[FileProcessor] File data:`,
@@ -573,19 +583,8 @@ export class FileProcessor extends BasePipelineStage {
             }
           }
 
-          // STEP 4: Cleanup all temp files in parallel (I/O bound)
-          console.log(
-            `[FileProcessor] Cleaning up ${downloadedFiles.length} temp file(s)...`,
-          );
-          const perfCleanupStart = performance.now();
-          await Promise.all(
-            downloadedFiles.map(({ filePath }) =>
-              this.fileProcessingService.cleanupFile(filePath),
-            ),
-          );
-          console.log(
-            `[Perf] FileProcessor.cleanupTempFiles: ${(performance.now() - perfCleanupStart).toFixed(1)}ms`,
-          );
+          // STEP 4 (temp-file cleanup) now lives in the finally block below
+          // so it also runs when any file fails processing.
 
           // STEP 5: Convert images to base64 for LLM consumption
           // Uses getBlobBase64String which handles both data URL strings and binary content
@@ -653,6 +652,29 @@ export class FileProcessor extends BasePipelineStage {
           });
           throw error;
         } finally {
+          // Best-effort cleanup of every downloaded temp file — success and
+          // failure paths alike. /tmp also hosts the chunked job store and
+          // chunk dirs, so stranded downloads here can starve the whole
+          // transcription pipeline of disk.
+          if (tempFilePaths.length > 0) {
+            const perfCleanupStart = performance.now();
+            const outcomes = await Promise.allSettled(
+              tempFilePaths.map((p) =>
+                this.fileProcessingService.cleanupFile(p),
+              ),
+            );
+            const failed = outcomes.filter(
+              (o) => o.status === 'rejected',
+            ).length;
+            if (failed > 0) {
+              console.warn(
+                `[FileProcessor] Failed to clean up ${failed}/${tempFilePaths.length} temp file(s)`,
+              );
+            }
+            console.log(
+              `[Perf] FileProcessor.cleanupTempFiles: ${(performance.now() - perfCleanupStart).toFixed(1)}ms (${tempFilePaths.length} files)`,
+            );
+          }
           span.end();
         }
       },

--- a/lib/services/transcription/batchJobRegistry.ts
+++ b/lib/services/transcription/batchJobRegistry.ts
@@ -9,6 +9,8 @@
  * Same persistence model and constraints as chunkedJobStore: JSON files
  * under /tmp, single-replica only.
  */
+import { sanitizeForLog } from '@/lib/utils/server/log/logSanitization';
+
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -61,8 +63,7 @@ export function recordBatchJobOwner(jobId: string, userId: string): void {
     pruneStaleRecords();
   } catch (err) {
     console.warn(
-      `[BatchJobRegistry] Could not record owner for job ${jobId}:`,
-      err,
+      `[BatchJobRegistry] Could not record owner for job ${sanitizeForLog(jobId)}: ${sanitizeForLog(err)}`,
     );
   }
 }
@@ -84,9 +85,10 @@ export function getBatchJobOwner(jobId: string): string | undefined {
     ) as BatchJobRecord;
     return typeof record.userId === 'string' ? record.userId : undefined;
   } catch (err) {
+    // jobId may have failed GUID validation here — sanitize it, and keep the
+    // log to a single argument so user input can't act as a format string.
     console.warn(
-      `[BatchJobRegistry] Could not read owner for job ${jobId}:`,
-      err,
+      `[BatchJobRegistry] Could not read owner for job ${sanitizeForLog(jobId)}: ${sanitizeForLog(err)}`,
     );
     return undefined;
   }
@@ -104,7 +106,7 @@ export function userOwnsBatchJob(jobId: string, userId: string): boolean {
   const owner = getBatchJobOwner(jobId);
   if (owner === undefined) {
     console.warn(
-      `[BatchJobRegistry] Denying access to unregistered batch job ${jobId}`,
+      `[BatchJobRegistry] Denying access to unregistered batch job ${sanitizeForLog(jobId)}`,
     );
     return false;
   }
@@ -120,8 +122,7 @@ export function deleteBatchJobRecord(jobId: string): void {
     }
   } catch (err) {
     console.warn(
-      `[BatchJobRegistry] Could not delete record for job ${jobId}:`,
-      err,
+      `[BatchJobRegistry] Could not delete record for job ${sanitizeForLog(jobId)}: ${sanitizeForLog(err)}`,
     );
   }
 }

--- a/lib/services/transcription/batchJobRegistry.ts
+++ b/lib/services/transcription/batchJobRegistry.ts
@@ -1,0 +1,155 @@
+/**
+ * File-based ownership registry for legacy Azure Batch transcription jobs.
+ *
+ * Batch jobs live in Azure and have no local job record, which historically
+ * meant any authenticated user who learned a job GUID could poll its status,
+ * read its transcript, or delete it. This registry records jobId → userId at
+ * submission time so the status and cleanup routes can enforce ownership.
+ *
+ * Same persistence model and constraints as chunkedJobStore: JSON files
+ * under /tmp, single-replica only.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+/** Directory for storing ownership records. */
+const REGISTRY_DIR = '/tmp/batch-transcription-jobs';
+
+/**
+ * How long to keep ownership records. Generous: Azure batch jobs can take
+ * hours, and a record outliving its job is harmless (lookups just 404 on the
+ * Azure side), while a record expiring early would lock the owner out.
+ */
+const RECORD_RETENTION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+/** Azure batch job IDs are GUIDs — same shape as chunked job IDs. */
+const BATCH_JOB_ID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+interface BatchJobRecord {
+  jobId: string;
+  userId: string;
+  createdAt: number;
+}
+
+function recordPath(jobId: string): string {
+  if (!BATCH_JOB_ID_REGEX.test(jobId)) {
+    throw new Error('Invalid batch job ID format');
+  }
+  return path.join(REGISTRY_DIR, `${jobId}.json`);
+}
+
+/**
+ * Records the owner of a freshly submitted batch transcription job.
+ * Never throws — a registry write failure must not fail the submission;
+ * the job just behaves like a pre-registry legacy job.
+ */
+export function recordBatchJobOwner(jobId: string, userId: string): void {
+  try {
+    const filePath = recordPath(jobId);
+    if (!fs.existsSync(REGISTRY_DIR)) {
+      fs.mkdirSync(REGISTRY_DIR, { recursive: true, mode: 0o700 });
+    }
+    const record: BatchJobRecord = { jobId, userId, createdAt: Date.now() };
+    // tmp-then-rename so concurrent readers never see a partial file.
+    const tmpPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+    fs.writeFileSync(tmpPath, JSON.stringify(record), {
+      encoding: 'utf-8',
+      mode: 0o600,
+    });
+    fs.renameSync(tmpPath, filePath);
+    pruneStaleRecords();
+  } catch (err) {
+    console.warn(
+      `[BatchJobRegistry] Could not record owner for job ${jobId}:`,
+      err,
+    );
+  }
+}
+
+/**
+ * Looks up the recorded owner of a batch job.
+ *
+ * @returns The owning userId, or undefined when no record exists (job
+ *   submitted before this registry was deployed, or record expired).
+ */
+export function getBatchJobOwner(jobId: string): string | undefined {
+  try {
+    const filePath = recordPath(jobId);
+    if (!fs.existsSync(filePath)) {
+      return undefined;
+    }
+    const record = JSON.parse(
+      fs.readFileSync(filePath, 'utf-8'),
+    ) as BatchJobRecord;
+    return typeof record.userId === 'string' ? record.userId : undefined;
+  } catch (err) {
+    console.warn(
+      `[BatchJobRegistry] Could not read owner for job ${jobId}:`,
+      err,
+    );
+    return undefined;
+  }
+}
+
+/**
+ * Checks whether the given user may access the given batch job.
+ *
+ * Policy: with a record, only the recorded owner may access. Without a
+ * record we DENY — an unknown GUID is more likely a probe than a legitimate
+ * pre-registry job, and the batch path is deprecated. Callers should return
+ * an indistinguishable 404 on denial to prevent jobId enumeration.
+ */
+export function userOwnsBatchJob(jobId: string, userId: string): boolean {
+  const owner = getBatchJobOwner(jobId);
+  if (owner === undefined) {
+    console.warn(
+      `[BatchJobRegistry] Denying access to unregistered batch job ${jobId}`,
+    );
+    return false;
+  }
+  return owner === userId;
+}
+
+/** Removes the ownership record (after the Azure-side job is deleted). */
+export function deleteBatchJobRecord(jobId: string): void {
+  try {
+    const filePath = recordPath(jobId);
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+    }
+  } catch (err) {
+    console.warn(
+      `[BatchJobRegistry] Could not delete record for job ${jobId}:`,
+      err,
+    );
+  }
+}
+
+/** Opportunistically removes records past retention. Never throws. */
+function pruneStaleRecords(): void {
+  try {
+    const now = Date.now();
+    for (const file of fs.readdirSync(REGISTRY_DIR)) {
+      if (!file.endsWith('.json')) continue;
+      const filePath = path.join(REGISTRY_DIR, file);
+      try {
+        const record = JSON.parse(
+          fs.readFileSync(filePath, 'utf-8'),
+        ) as BatchJobRecord;
+        if (now - record.createdAt > RECORD_RETENTION_MS) {
+          fs.unlinkSync(filePath);
+        }
+      } catch {
+        // Unreadable record — remove it so it can't shadow a future job.
+        try {
+          fs.unlinkSync(filePath);
+        } catch {
+          // Best-effort.
+        }
+      }
+    }
+  } catch {
+    // Directory unreadable — nothing to prune.
+  }
+}

--- a/lib/services/transcription/chunkedJobStore.ts
+++ b/lib/services/transcription/chunkedJobStore.ts
@@ -11,6 +11,7 @@
 import { TranscriptionErrorClass } from '@/types/transcription';
 
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 
 export type ChunkedJobStatus =
@@ -45,8 +46,6 @@ export interface ChunkedJob {
   errorClass?: TranscriptionErrorClass;
   /** Paths to chunk files (for cleanup) */
   chunkPaths: string[];
-  /** Path to original audio file (for cleanup) */
-  originalAudioPath?: string;
   /** Original filename for display */
   filename: string;
   /** Job creation timestamp */
@@ -58,8 +57,15 @@ export interface ChunkedJob {
 /** Directory for storing job JSON files */
 const JOB_STORE_DIR = '/tmp/chunked-transcription-jobs';
 
-/** How long to keep completed/failed jobs before cleanup (1 hour) */
-const JOB_RETENTION_MS = 60 * 60 * 1000;
+/**
+ * How long to keep completed/failed jobs before cleanup.
+ *
+ * Must exceed the client's maximum polling window
+ * (MAX_TRANSCRIPTION_TIMEOUT_MS in useTranscriptionPolling.ts, currently 2h),
+ * otherwise a client that reconnects late polls a 404 and a completed
+ * transcript is silently lost. 3h = client ceiling + 1h slack.
+ */
+const JOB_RETENTION_MS = 3 * 60 * 60 * 1000;
 
 /**
  * Validates that a job ID contains only safe characters.
@@ -128,6 +134,112 @@ function saveJob(job: ChunkedJob): void {
   fs.renameSync(tmpPath, filePath);
 }
 
+/** How long a held lock may live before another writer treats it as stale. */
+const LOCK_STALE_MS = 2_000;
+/** Sleep between lock-acquisition attempts. */
+const LOCK_RETRY_DELAY_MS = 5;
+/** Give up acquiring the lock after this long and fall back to lock-free. */
+const LOCK_MAX_WAIT_MS = 250;
+
+// Atomics.wait needs a SharedArrayBuffer-backed view; this one exists solely
+// to implement a synchronous sleep without spinning the CPU.
+const lockSleepBuffer = new Int32Array(new SharedArrayBuffer(4));
+
+function sleepSync(ms: number): void {
+  Atomics.wait(lockSleepBuffer, 0, 0, ms);
+}
+
+/**
+ * Acquires a per-job advisory lock (a lock directory next to the job file).
+ *
+ * Within one Node process the store's synchronous read-modify-write calls
+ * already can't interleave; this lock guards the cross-process case (e.g.
+ * a cluster-mode deployment that violates the documented single-replica
+ * assumption) so a cancel can't be silently clobbered by a concurrent
+ * progress write. Locks held longer than LOCK_STALE_MS are assumed to come
+ * from a crashed process and are broken.
+ *
+ * @returns A release function, or null if the lock could not be acquired
+ *   within LOCK_MAX_WAIT_MS (callers proceed lock-free rather than failing).
+ */
+function acquireJobLock(jobId: string): (() => void) | null {
+  validateJobId(jobId);
+  ensureStoreDir();
+  const lockDir = path.join(JOB_STORE_DIR, `${jobId}.lock`);
+  const deadline = Date.now() + LOCK_MAX_WAIT_MS;
+
+  for (;;) {
+    try {
+      fs.mkdirSync(lockDir);
+      return () => {
+        try {
+          fs.rmdirSync(lockDir);
+        } catch {
+          // Already removed (e.g. broken as stale by another writer).
+        }
+      };
+    } catch {
+      // Lock exists — break it if stale, otherwise wait and retry.
+      try {
+        const lockAge = Date.now() - fs.statSync(lockDir).mtimeMs;
+        if (lockAge > LOCK_STALE_MS) {
+          try {
+            fs.rmdirSync(lockDir);
+          } catch {
+            // Another writer broke it first.
+          }
+          continue;
+        }
+      } catch {
+        // Lock vanished between mkdir and stat — retry immediately.
+        continue;
+      }
+      if (Date.now() >= deadline) {
+        console.warn(
+          `[ChunkedJobStore] Could not acquire lock for job ${jobId} within ${LOCK_MAX_WAIT_MS}ms; proceeding without it`,
+        );
+        return null;
+      }
+      sleepSync(LOCK_RETRY_DELAY_MS);
+    }
+  }
+}
+
+/**
+ * Reads the job, applies `apply` only while the job is still active
+ * (pending/processing), and persists the result — all under the per-job
+ * advisory lock so the freshest state is what gets checked and written.
+ *
+ * This is the single write path for status transitions: terminal states
+ * (succeeded/failed/cancelled) can never be overwritten by a late progress
+ * update or a racing completion.
+ *
+ * @returns true if the mutation was applied; false if the job was already
+ *   terminal and the call was a no-op.
+ * @throws Error when no job record exists for `jobId`.
+ */
+function mutateActiveJob(
+  jobId: string,
+  apply: (job: ChunkedJob) => void,
+): boolean {
+  const release = acquireJobLock(jobId);
+  try {
+    const job = getJob(jobId);
+    if (!job) {
+      throw new Error(`Job ${jobId} not found`);
+    }
+    if (job.status !== 'pending' && job.status !== 'processing') {
+      return false;
+    }
+    apply(job);
+    job.updatedAt = Date.now();
+    saveJob(job);
+    return true;
+  } finally {
+    release?.();
+  }
+}
+
 /**
  * Creates a new chunked transcription job.
  *
@@ -144,7 +256,6 @@ export function createJob(
   totalChunks: number,
   chunkPaths: string[],
   filename: string,
-  originalAudioPath?: string,
 ): void {
   const now = Date.now();
 
@@ -156,7 +267,6 @@ export function createJob(
     completedChunks: 0,
     currentChunk: 0,
     chunkPaths,
-    originalAudioPath,
     filename,
     createdAt: now,
     updatedAt: now,
@@ -186,31 +296,22 @@ export function updateProgress(
   completedChunks: number,
   currentChunk?: number,
 ): void {
-  const job = getJob(jobId);
-  if (!job) {
-    throw new Error(`Job ${jobId} not found`);
+  // mutateActiveJob bails if the job is already terminal — a background
+  // chunk that finishes after the user cancelled (or after a failure was
+  // recorded) must not clobber the terminal status back to 'processing'.
+  const applied = mutateActiveJob(jobId, (job) => {
+    job.status = 'processing';
+    job.completedChunks = completedChunks;
+    if (currentChunk !== undefined) {
+      job.currentChunk = currentChunk;
+    }
+  });
+
+  if (applied) {
+    console.log(
+      `[ChunkedJobStore] Job ${jobId} progress: ${completedChunks} chunks completed`,
+    );
   }
-
-  // Bail if the job is already terminal — a background chunk that finishes
-  // after the user cancelled (or after a failure was recorded) must not
-  // clobber the terminal status back to 'processing'. Racing writes are
-  // otherwise resolved last-writer-wins by the tmp+rename save path.
-  if (job.status !== 'pending' && job.status !== 'processing') {
-    return;
-  }
-
-  job.status = 'processing';
-  job.completedChunks = completedChunks;
-  if (currentChunk !== undefined) {
-    job.currentChunk = currentChunk;
-  }
-  job.updatedAt = Date.now();
-
-  saveJob(job);
-
-  console.log(
-    `[ChunkedJobStore] Job ${jobId} progress: ${completedChunks}/${job.totalChunks} chunks`,
-  );
 }
 
 /**
@@ -221,29 +322,21 @@ export function updateProgress(
  * @throws Error when no job record exists for `jobId`.
  */
 export function completeJob(jobId: string, transcript: string): void {
-  const job = getJob(jobId);
-  if (!job) {
-    throw new Error(`Job ${jobId} not found`);
-  }
-
-  // Preserve terminal status. If the user cancelled while the final batch
-  // was in flight, the combined-transcript write must not flip the job
+  // Preserve terminal status. If the user cancelled while the final chunks
+  // were in flight, the combined-transcript write must not flip the job
   // back to 'succeeded'. The transcript is discarded by design — cancelled
   // means the user doesn't want it.
-  if (job.status !== 'pending' && job.status !== 'processing') {
-    return;
+  const applied = mutateActiveJob(jobId, (job) => {
+    job.status = 'succeeded';
+    job.completedChunks = job.totalChunks;
+    job.transcript = transcript;
+  });
+
+  if (applied) {
+    console.log(
+      `[ChunkedJobStore] Job ${jobId} completed successfully with ${transcript.length} chars`,
+    );
   }
-
-  job.status = 'succeeded';
-  job.completedChunks = job.totalChunks;
-  job.transcript = transcript;
-  job.updatedAt = Date.now();
-
-  saveJob(job);
-
-  console.log(
-    `[ChunkedJobStore] Job ${jobId} completed successfully with ${transcript.length} chars`,
-  );
 }
 
 /**
@@ -260,29 +353,21 @@ export function failJob(
   error: string,
   errorClass?: TranscriptionErrorClass,
 ): void {
-  const job = getJob(jobId);
-  if (!job) {
-    throw new Error(`Job ${jobId} not found`);
-  }
-
   // Preserve terminal status. A background chunk that errors after the user
   // cancelled (or after a different branch already recorded success/failure)
   // must not flip the stored outcome — cancelled must stay cancelled, a
   // succeeded job must not revert to failed.
-  if (job.status !== 'pending' && job.status !== 'processing') {
-    return;
+  const applied = mutateActiveJob(jobId, (job) => {
+    job.status = 'failed';
+    job.error = error;
+    job.errorClass = errorClass;
+  });
+
+  if (applied) {
+    console.error(
+      `[ChunkedJobStore] Job ${jobId} failed (${errorClass ?? 'unclassified'}): ${error}`,
+    );
   }
-
-  job.status = 'failed';
-  job.error = error;
-  job.errorClass = errorClass;
-  job.updatedAt = Date.now();
-
-  saveJob(job);
-
-  console.error(
-    `[ChunkedJobStore] Job ${jobId} failed (${errorClass ?? 'unclassified'}): ${error}`,
-  );
 }
 
 /**
@@ -380,11 +465,42 @@ export function getActiveJobCount(): number {
   ).length;
 }
 
+/** Root directory holding per-job chunk subdirectories. */
+const CHUNK_DIR_ROOT = path.join(os.tmpdir(), 'chunked-transcription');
+
+/**
+ * Best-effort removal of a job's on-disk chunk artifacts: the chunk files
+ * themselves plus any per-job directory under the chunked-transcription
+ * tmpdir root. Never throws — artifact cleanup must not block status
+ * reconciliation.
+ */
+function cleanupJobArtifacts(job: ChunkedJob): void {
+  for (const chunkPath of job.chunkPaths) {
+    try {
+      fs.unlinkSync(chunkPath);
+    } catch {
+      // Already gone or unreadable — nothing useful to do.
+    }
+  }
+  const parents = new Set(job.chunkPaths.map((p) => path.dirname(p)));
+  for (const parent of parents) {
+    if (parent.startsWith(CHUNK_DIR_ROOT + path.sep)) {
+      try {
+        fs.rmSync(parent, { recursive: true, force: true });
+      } catch {
+        // Best-effort.
+      }
+    }
+  }
+}
+
 /**
  * Marks any job that was mid-flight (pending or processing) when the server
- * was last stopped as failed with a recognizable reason. Intended to be
- * called once at server startup so clients polling such jobs see a clean
- * failure rather than a permanent 404.
+ * was last stopped as failed with a recognizable reason, and removes the
+ * job's chunk files — they can never be consumed once the in-process
+ * pipeline that produced them is gone. Intended to be called once at server
+ * startup so clients polling such jobs see a clean failure rather than a
+ * permanent 404.
  *
  * @returns The job IDs that were marked failed.
  */
@@ -404,6 +520,9 @@ export function markInterruptedJobsFailed(): string[] {
         err,
       );
     }
+    // Even if the status write failed, the chunks are unusable — reclaim
+    // the disk either way.
+    cleanupJobArtifacts(job);
   }
   if (marked.length > 0) {
     console.log(
@@ -414,29 +533,71 @@ export function markInterruptedJobsFailed(): string[] {
 }
 
 /**
+ * Removes per-job chunk directories whose job record no longer exists or is
+ * already terminal. Safe to run at startup (no job can be actively writing
+ * chunks yet) — covers dirs orphaned by crashes that predate their job
+ * record, and dirs whose record was already removed by retention cleanup.
+ *
+ * @returns The directory names that were removed.
+ */
+export function sweepOrphanedChunkDirs(): string[] {
+  const removed: string[] = [];
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(CHUNK_DIR_ROOT, { withFileTypes: true });
+  } catch {
+    // Root doesn't exist yet — nothing to sweep.
+    return removed;
+  }
+
+  const liveJobIds = new Set(
+    listJobs()
+      .filter((job) => job.status === 'pending' || job.status === 'processing')
+      .map((job) => job.jobId),
+  );
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (liveJobIds.has(entry.name)) continue;
+    try {
+      fs.rmSync(path.join(CHUNK_DIR_ROOT, entry.name), {
+        recursive: true,
+        force: true,
+      });
+      removed.push(entry.name);
+    } catch (err) {
+      console.warn(
+        `[ChunkedJobStore] Could not remove orphaned chunk dir ${entry.name}:`,
+        err,
+      );
+    }
+  }
+
+  if (removed.length > 0) {
+    console.log(
+      `[ChunkedJobStore] Swept ${removed.length} orphaned chunk dir(s)`,
+    );
+  }
+  return removed;
+}
+
+/**
  * Marks a job as cancelled by the user. Cooperative — the background chunk
  * processor polls job status between batches and aborts when it sees this.
  *
  * @throws Error when no job record exists for `jobId`.
  */
 export function cancelJob(jobId: string): void {
-  const job = getJob(jobId);
-  if (!job) {
-    throw new Error(`Job ${jobId} not found`);
+  // mutateActiveJob no-ops (returns false) when the job is already terminal.
+  const applied = mutateActiveJob(jobId, (job) => {
+    job.status = 'cancelled';
+    job.error = JOB_CANCELLED_MESSAGE;
+  });
+
+  if (applied) {
+    console.log(`[ChunkedJobStore] Job ${jobId} cancelled by user`);
   }
-  // Already terminal — no-op.
-  if (
-    job.status === 'succeeded' ||
-    job.status === 'failed' ||
-    job.status === 'cancelled'
-  ) {
-    return;
-  }
-  job.status = 'cancelled';
-  job.error = JOB_CANCELLED_MESSAGE;
-  job.updatedAt = Date.now();
-  saveJob(job);
-  console.log(`[ChunkedJobStore] Job ${jobId} cancelled by user`);
 }
 
 // Cleanup timer reference

--- a/lib/services/transcription/chunkedTranscriptionService.ts
+++ b/lib/services/transcription/chunkedTranscriptionService.ts
@@ -35,28 +35,44 @@ import { WhisperTranscriptionService } from './whisperTranscriptionService';
 import { v4 as uuidv4 } from 'uuid';
 
 /**
+ * Parses a non-negative integer env knob. Unlike `Number(x) || fallback`,
+ * an explicit "0" is honored (the || idiom silently turned 0 back into the
+ * fallback). Malformed, negative, or fractional values fall back with a
+ * warning rather than poisoning the math downstream.
+ */
+function parseEnvInt(name: string, fallback: number, min: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return fallback;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < min) {
+    console.warn(
+      `[ChunkedTranscription] Ignoring invalid ${name}="${raw}" (need integer >= ${min}); using ${fallback}`,
+    );
+    return fallback;
+  }
+  return parsed;
+}
+
+/**
  * Number of chunks to process in parallel. Tunable at deploy time via
  * TRANSCRIPTION_CONCURRENCY — higher if your Whisper deployment has more
  * throughput, lower if you're hitting 429s.
  */
-const MAX_CONCURRENT_CHUNKS = Math.max(
-  1,
-  Number(process.env.TRANSCRIPTION_CONCURRENCY) || 3,
-);
+const MAX_CONCURRENT_CHUNKS = parseEnvInt('TRANSCRIPTION_CONCURRENCY', 3, 1);
 
 /**
  * Total attempts per chunk (1 initial call + additional retries on transient
  * failure). Tunable via TRANSCRIPTION_RETRIES, which expresses *retries* for
- * legacy compatibility; the loop uses ATTEMPTS = retries + 1.
+ * legacy compatibility; the loop uses ATTEMPTS = retries + 1. An explicit
+ * TRANSCRIPTION_RETRIES=0 means "one attempt, no retries".
  */
-const TRANSCRIPTION_RETRIES = Math.max(
-  0,
-  Number(process.env.TRANSCRIPTION_RETRIES) || 2,
-);
+const TRANSCRIPTION_RETRIES = parseEnvInt('TRANSCRIPTION_RETRIES', 2, 0);
 const MAX_CHUNK_ATTEMPTS = TRANSCRIPTION_RETRIES + 1;
 
-/** Delay before retry after failure (ms) */
-const RETRY_DELAY_MS = 2000;
+/** Base delay before the first retry (ms); doubles per attempt. */
+const RETRY_BASE_DELAY_MS = 2000;
+/** Ceiling for computed backoff (server Retry-After may exceed this). */
+const RETRY_MAX_DELAY_MS = 30_000;
 
 export interface ChunkedTranscriptionOptions extends TranscriptionOptions {
   /** Called when progress is updated */
@@ -145,7 +161,7 @@ export class ChunkedTranscriptionService {
     );
 
     // Create job in store
-    createJob(jobId, userId, chunkCount, chunkPaths, filename, audioPath);
+    createJob(jobId, userId, chunkCount, chunkPaths, filename);
 
     // Start async processing (don't await - runs in background)
     this.processChunksAsync(jobId, chunkPaths, filename, options).catch(
@@ -183,13 +199,21 @@ export class ChunkedTranscriptionService {
   }
 
   /**
-   * Processes chunks asynchronously in the background using parallel batches.
+   * Processes chunks asynchronously in the background using a worker pool.
    *
    * This method is called without await from startJob() and runs
    * independently, updating the job store as it progresses.
    *
-   * Chunks are processed in parallel batches of MAX_CONCURRENT_CHUNKS,
-   * but results are sorted by index to maintain original order.
+   * MAX_CONCURRENT_CHUNKS workers pull the next unclaimed chunk as soon as
+   * they finish their current one — unlike lockstep batches, one slow or
+   * retrying chunk never idles the other slots. Results are sorted by index
+   * at the end to restore playback order.
+   *
+   * Workers adapt cooperatively:
+   * - before each chunk they re-check the job store, so a user cancel stops
+   *   new work within one chunk;
+   * - the first fatal chunk error sets an abort flag that stops the other
+   *   workers from claiming new chunks (and aborts their in-flight retries).
    */
   private async processChunksAsync(
     jobId: string,
@@ -205,69 +229,75 @@ export class ChunkedTranscriptionService {
         `(${totalChunks} chunks, max ${MAX_CONCURRENT_CHUNKS} concurrent)`,
     );
 
-    try {
-      // Process chunks in parallel batches
-      for (
-        let batchStart = 0;
-        batchStart < totalChunks;
-        batchStart += MAX_CONCURRENT_CHUNKS
-      ) {
-        // Cooperative cancel check between batches — if the user cancelled
-        // or the job was externally terminated, stop burning Whisper calls.
-        const current = getJob(jobId);
-        if (!current || current.status === 'cancelled') {
-          console.log(
-            `[ChunkedTranscription] Job ${jobId} cancelled; aborting remaining chunks`,
-          );
+    let nextIndex = 0;
+    let cancelled = false;
+    let fatalError: Error | null = null;
+
+    const isJobCancelled = (): boolean => {
+      const current = getJob(jobId);
+      return !current || current.status === 'cancelled';
+    };
+    const shouldAbort = (): boolean => cancelled || fatalError !== null;
+
+    const worker = async (): Promise<void> => {
+      for (;;) {
+        if (shouldAbort()) return;
+
+        const index = nextIndex++;
+        if (index >= totalChunks) return;
+
+        // Cooperative cancel check before claiming Whisper capacity.
+        if (isJobCancelled()) {
+          cancelled = true;
           return;
         }
 
-        const batchEnd = Math.min(
-          batchStart + MAX_CONCURRENT_CHUNKS,
-          totalChunks,
-        );
-        const batchChunkPaths = chunkPaths.slice(batchStart, batchEnd);
-
+        const chunkNum = index + 1;
         console.log(
-          `[ChunkedTranscription] Processing batch: chunks ${batchStart + 1}-${batchEnd} of ${totalChunks}`,
+          `[ChunkedTranscription] Transcribing chunk ${chunkNum}/${totalChunks}: ${chunkPaths[index]}`,
         );
 
-        // Update progress at batch start
-        updateProgress(jobId, results.length, batchStart);
+        try {
+          const transcript = await this.transcribeChunkWithRetry(
+            chunkPaths[index],
+            chunkNum,
+            totalChunks,
+            options,
+            shouldAbort,
+          );
+          results.push({ index, transcript });
+          // updateProgress no-ops once the job is terminal (e.g. cancelled
+          // while this chunk was in flight), so this can't resurrect it.
+          updateProgress(jobId, results.length, index);
+          options?.onProgress?.(results.length, totalChunks);
+        } catch (error) {
+          if (!fatalError) {
+            fatalError =
+              error instanceof Error ? error : new Error(String(error));
+          }
+          return;
+        }
+      }
+    };
 
-        // Process this batch in parallel
-        const batchPromises = batchChunkPaths.map(
-          async (chunkPath, batchIndex) => {
-            const globalIndex = batchStart + batchIndex;
-            const chunkNum = globalIndex + 1;
+    try {
+      updateProgress(jobId, 0, 0);
 
-            console.log(
-              `[ChunkedTranscription] Transcribing chunk ${chunkNum}/${totalChunks}: ${chunkPath}`,
-            );
+      const workerCount = Math.min(MAX_CONCURRENT_CHUNKS, totalChunks);
+      await Promise.all(Array.from({ length: workerCount }, () => worker()));
 
-            const transcript = await this.transcribeChunkWithRetry(
-              chunkPath,
-              chunkNum,
-              totalChunks,
-              options,
-            );
-
-            return { index: globalIndex, transcript };
-          },
+      if (cancelled || isJobCancelled()) {
+        console.log(
+          `[ChunkedTranscription] Job ${jobId} cancelled; aborted remaining chunks`,
         );
-
-        // Wait for all chunks in this batch to complete
-        const batchResults = await Promise.all(batchPromises);
-        results.push(...batchResults);
-
-        // Update progress after batch completes
-        updateProgress(jobId, results.length, batchEnd - 1);
-
-        // Call progress callback if provided
-        options?.onProgress?.(results.length, totalChunks);
+        return;
       }
 
-      // Sort by index to ensure correct order (parallel results may arrive out of order)
+      if (fatalError) {
+        throw fatalError;
+      }
+
+      // Sort by index to ensure correct order (parallel results arrive out of order)
       results.sort((a, b) => a.index - b.index);
       const transcripts = results.map((r) => r.transcript);
 
@@ -306,20 +336,38 @@ export class ChunkedTranscriptionService {
    * - `permanent`: don't retry (user error — bad codec, oversized, etc.).
    * - `auth`: rebuild the Whisper client once (handles token expiry on long jobs)
    *           and retry.
-   * - `rate_limit`: retry with doubled backoff.
-   * - `transient` / `unknown`: retry with normal backoff.
+   * - `rate_limit`: wait for the server's Retry-After when it sent one,
+   *           otherwise exponential backoff at double weight.
+   * - `transient` / `unknown`: exponential backoff with jitter.
+   *
+   * `shouldAbort` is checked before every attempt and after every backoff
+   * sleep so a cancelled job (or a sibling worker's fatal error) stops the
+   * retry sequence instead of burning the full schedule.
    */
   private async transcribeChunkWithRetry(
     chunkPath: string,
     chunkNum: number,
     totalChunks: number,
     options?: TranscriptionOptions,
+    shouldAbort: () => boolean = () => false,
   ): Promise<string> {
     let lastError: Error | undefined;
 
     for (let attempt = 1; attempt <= MAX_CHUNK_ATTEMPTS; attempt++) {
+      if (shouldAbort()) {
+        throw (
+          lastError ??
+          Object.assign(
+            new Error(
+              `Transcription of chunk ${chunkNum}/${totalChunks} aborted`,
+            ) as TranscriptionError,
+            { errorClass: 'transient' as TranscriptionErrorClass },
+          )
+        );
+      }
+
       try {
-        const transcript = await this.whisperService.transcribe(
+        const transcript = await this.whisperService.transcribeChunk(
           chunkPath,
           options,
         );
@@ -327,8 +375,9 @@ export class ChunkedTranscriptionService {
       } catch (error) {
         lastError = error instanceof Error ? error : new Error(String(error));
 
+        const tagged = lastError as TranscriptionError;
         const errorClass: TranscriptionErrorClass =
-          (lastError as TranscriptionError).errorClass ?? 'unknown';
+          tagged.errorClass ?? 'unknown';
 
         if (errorClass === 'permanent') {
           // User-visible error (bad codec, oversize, etc.); don't waste retries.
@@ -343,12 +392,13 @@ export class ChunkedTranscriptionService {
             `[ChunkedTranscription] Chunk ${chunkNum}/${totalChunks} hit auth error; re-initializing Whisper client`,
           );
           this.whisperService = new WhisperTranscriptionService();
-          await delay(RETRY_DELAY_MS);
-          continue;
         }
 
-        const waitTime =
-          errorClass === 'rate_limit' ? RETRY_DELAY_MS * 2 : RETRY_DELAY_MS;
+        const waitTime = computeBackoffMs(
+          attempt,
+          errorClass,
+          tagged.retryAfterSeconds,
+        );
 
         console.warn(
           `[ChunkedTranscription] Chunk ${chunkNum}/${totalChunks} failed (${errorClass}, ` +
@@ -360,9 +410,9 @@ export class ChunkedTranscriptionService {
     }
 
     // `lastError` is always assigned on any iteration that takes the catch
-    // branch, and the loop runs at least once (MAX_CHUNK_ATTEMPTS ≥ 1 is
-    // enforced via TRANSCRIPTION_RETRIES = Math.max(0, …)). If the loop
-    // returns successfully on the first try we never reach here.
+    // branch, and the loop runs at least once (MAX_CHUNK_ATTEMPTS ≥ 1 since
+    // parseEnvInt enforces TRANSCRIPTION_RETRIES ≥ 0). If the loop returns
+    // successfully on the first try we never reach here.
     const tagged = lastError as TranscriptionError | undefined;
     const err = new Error(
       `Failed to transcribe chunk ${chunkNum}/${totalChunks} after ${MAX_CHUNK_ATTEMPTS} attempts: ${tagged?.message ?? 'unknown error'}`,
@@ -409,6 +459,34 @@ export class ChunkedTranscriptionService {
  */
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Computes the wait before retry attempt `attempt + 1`.
+ *
+ * Exponential (base doubles per attempt, capped at RETRY_MAX_DELAY_MS) with
+ * full-range jitter so parallel workers that failed together don't retry in
+ * lockstep and re-trigger the same rate limit. When the server sent a
+ * Retry-After, that takes precedence (plus a little jitter) — the server
+ * knows its own capacity better than our schedule does.
+ */
+function computeBackoffMs(
+  attempt: number,
+  errorClass: TranscriptionErrorClass,
+  retryAfterSeconds?: number,
+): number {
+  if (errorClass === 'rate_limit' && retryAfterSeconds) {
+    // Honor the server's wait, with up to +25% jitter to spread workers out.
+    return Math.round(retryAfterSeconds * 1000 * (1 + Math.random() * 0.25));
+  }
+
+  const weight = errorClass === 'rate_limit' ? 2 : 1;
+  const exponential = Math.min(
+    RETRY_BASE_DELAY_MS * weight * 2 ** (attempt - 1),
+    RETRY_MAX_DELAY_MS,
+  );
+  // Jitter across [50%, 100%] of the computed delay.
+  return Math.round(exponential * (0.5 + Math.random() * 0.5));
 }
 
 /**

--- a/lib/services/transcription/common.ts
+++ b/lib/services/transcription/common.ts
@@ -1,51 +1,59 @@
 import { sanitizeForLog } from '@/lib/utils/server/log/logSanitization';
 
+import { randomUUID } from 'crypto';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { promisify } from 'util';
 
-const unlinkAsync = promisify(fs.unlink);
+/** Cheap shape check: base64 alphabet, optional padding, length % 4 === 0. */
+const BASE64_SHAPE_REGEX = /^[A-Za-z0-9+/]+={0,2}$/;
 
+/**
+ * Heuristic: is this string a base64 payload (vs. a file path)?
+ *
+ * The cheap shape check rejects file paths immediately — extensions ('.'),
+ * underscores, and hyphens are not base64 characters — without paying for a
+ * decode of a potentially multi-megabyte string. Strings that pass the shape
+ * check still get the strict decode/re-encode round trip, preserving the
+ * original semantics (only canonical base64 of valid UTF-8 qualifies).
+ */
 export function isBase64(str: string): boolean {
-  console.time('isBase64');
+  if (!str || str.length % 4 !== 0 || !BASE64_SHAPE_REGEX.test(str)) {
+    return false;
+  }
   try {
-    const result =
+    return (
       Buffer.from(Buffer.from(str, 'base64').toString('utf8')).toString(
         'base64',
-      ) === str;
-    console.timeEnd('isBase64');
-    return result;
-  } catch (err) {
-    console.timeEnd('isBase64');
+      ) === str
+    );
+  } catch {
     return false;
   }
 }
 
 export async function saveBase64AsFile(base64String: string): Promise<string> {
-  console.time('saveBase64AsFile');
-  console.log('Saving base64 string as file...');
-  const tempFilePath = path.join(os.tmpdir(), `temp_audio_${Date.now()}.wav`);
+  // randomUUID (not a timestamp) — concurrent chunk transcriptions must not
+  // collide on the same temp filename within one millisecond.
+  const tempFilePath = path.join(os.tmpdir(), `temp_audio_${randomUUID()}.wav`);
   const buffer = Buffer.from(base64String, 'base64');
   // Write file with secure permissions (0o600 = read/write for owner only)
   await fs.promises.writeFile(tempFilePath, new Uint8Array(buffer), {
     mode: 0o600,
   });
-  console.log(`File saved at: ${tempFilePath}`);
-  console.timeEnd('saveBase64AsFile');
+  console.log(`[Transcription] Saved base64 input to: ${tempFilePath}`);
   return tempFilePath;
 }
 
-export function cleanUpFiles(filePaths: string[]): Promise<void[]> {
-  console.time('cleanUpFiles');
-  console.log(`Cleaning up ${filePaths.length} files...`);
-  const unlinkPromises = filePaths.map(async (filePath) => {
-    await fs.promises
-      .access(filePath)
-      .then(() => unlinkAsync(filePath))
-      .then(() => console.log(`Deleted file: ${sanitizeForLog(filePath)}`))
-      .catch(() => console.log(`File not found: ${sanitizeForLog(filePath)}`));
-  });
-  console.timeEnd('cleanUpFiles');
-  return Promise.all(unlinkPromises);
+export async function cleanUpFiles(filePaths: string[]): Promise<void> {
+  await Promise.all(
+    filePaths.map(async (filePath) => {
+      try {
+        await fs.promises.unlink(filePath);
+        console.log(`Deleted file: ${sanitizeForLog(filePath)}`);
+      } catch {
+        console.log(`File not found: ${sanitizeForLog(filePath)}`);
+      }
+    }),
+  );
 }

--- a/lib/services/transcription/whisperTranscriptionService.ts
+++ b/lib/services/transcription/whisperTranscriptionService.ts
@@ -22,7 +22,6 @@ import fs from 'fs';
 import { AzureOpenAI } from 'openai';
 
 export class WhisperTranscriptionService implements ITranscriptionService {
-  private modelName: string = 'whisper-1';
   private deployment: string;
   private client: AzureOpenAI;
 
@@ -101,18 +100,25 @@ export class WhisperTranscriptionService implements ITranscriptionService {
     }
   }
 
-  private async transcribeSegment(
-    segmentPath: string,
+  /**
+   * Transcribes one chunk of a larger recording (the chunked pipeline's
+   * entry point). Has its own size check with chunk-appropriate wording:
+   * the user uploaded a whole recording, not this chunk, so the whole-file
+   * "please upload a shorter audio file" message from transcribe() would
+   * mislead. The splitter's post-split size check makes this a backstop —
+   * reaching it means a chunk slipped through oversized anyway.
+   */
+  async transcribeChunk(
+    chunkPath: string,
     options?: TranscriptionOptions,
   ): Promise<string> {
-    const stats = await fs.promises.stat(segmentPath);
+    const stats = await fs.promises.stat(chunkPath);
     const fileSize = stats.size;
 
     if (fileSize > WHISPER_MAX_SIZE) {
       const maxSizeMB = WHISPER_MAX_SIZE / (1024 * 1024);
       // Tagged permanent so the chunked retry loop fails fast instead of
-      // re-sending a chunk that can never fit under the API limit. Worded
-      // for end users, who never created "segments" themselves.
+      // re-sending a chunk that can never fit under the API limit.
       const sizeError = new Error(
         `Part of this recording came out larger than the ${maxSizeMB}MB transcription limit. ` +
           `Please try a shorter recording.`,
@@ -121,6 +127,13 @@ export class WhisperTranscriptionService implements ITranscriptionService {
       throw sizeError;
     }
 
+    return this.transcribeSegment(chunkPath, options);
+  }
+
+  private async transcribeSegment(
+    segmentPath: string,
+    options?: TranscriptionOptions,
+  ): Promise<string> {
     try {
       // Use OpenAI SDK which handles file streams properly
       const transcription = await this.client.audio.transcriptions.create({
@@ -136,19 +149,23 @@ export class WhisperTranscriptionService implements ITranscriptionService {
 
       return transcription.text || '';
     } catch (error: unknown) {
-      const err = error as { status?: number; code?: string; message?: string };
+      const err = error as {
+        status?: number;
+        code?: string;
+        message?: string;
+        headers?: Record<string, string> | Headers;
+      };
       const status = err.status;
       const code = err.code;
 
       let errorClass: TranscriptionErrorClass = 'unknown';
       let message = err.message || 'Unknown error';
+      let retryAfterSeconds: number | undefined;
 
       if (status === 429 || code === 'rate_limit_exceeded') {
         errorClass = 'rate_limit';
-        const retryAfterMatch = err.message?.match(
-          /retry after (\d+) seconds?/i,
-        );
-        const waitTime = retryAfterMatch ? retryAfterMatch[1] : 'a few';
+        retryAfterSeconds = extractRetryAfterSeconds(err);
+        const waitTime = retryAfterSeconds ?? 'a few';
         message = `The audio transcription service is currently at capacity due to high usage. Please wait ${waitTime} seconds and try again.`;
       } else if (status === 401 || status === 403) {
         errorClass = 'auth';
@@ -168,7 +185,39 @@ export class WhisperTranscriptionService implements ITranscriptionService {
         `Error transcribing segment: ${message}`,
       ) as TranscriptionError;
       tagged.errorClass = errorClass;
+      tagged.retryAfterSeconds = retryAfterSeconds;
       throw tagged;
     }
   }
+}
+
+/**
+ * Pulls the server-suggested retry delay (seconds) out of a rate-limit
+ * error, preferring the Retry-After header over the message text. Returns
+ * undefined when the server didn't say (callers fall back to their own
+ * backoff) or when the value is nonsensical.
+ */
+function extractRetryAfterSeconds(err: {
+  message?: string;
+  headers?: Record<string, string> | Headers;
+}): number | undefined {
+  let headerValue: string | undefined;
+  if (err.headers instanceof Headers) {
+    headerValue = err.headers.get('retry-after') ?? undefined;
+  } else if (err.headers) {
+    headerValue = err.headers['retry-after'] ?? err.headers['Retry-After'];
+  }
+
+  const candidates = [
+    headerValue,
+    err.message?.match(/retry after (\d+) seconds?/i)?.[1],
+  ];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const parsed = Number(candidate);
+    if (Number.isFinite(parsed) && parsed > 0 && parsed <= 600) {
+      return Math.ceil(parsed);
+    }
+  }
+  return undefined;
 }

--- a/lib/services/transcription/whisperTranscriptionService.ts
+++ b/lib/services/transcription/whisperTranscriptionService.ts
@@ -81,9 +81,12 @@ export class WhisperTranscriptionService implements ITranscriptionService {
 
       if (fileSize > WHISPER_MAX_SIZE) {
         const maxSizeMB = WHISPER_MAX_SIZE / (1024 * 1024);
-        throw new Error(
+        // Tagged permanent: the file will never shrink, so retrying is futile.
+        const sizeError = new Error(
           `Audio file size (${(fileSize / 1024 / 1024).toFixed(2)}MB) exceeds the maximum limit of ${maxSizeMB}MB. Please upload a shorter audio file.`,
-        );
+        ) as TranscriptionError;
+        sizeError.errorClass = 'permanent';
+        throw sizeError;
       }
 
       // Transcribe the file directly (Whisper supports mp3, mp4, mpeg, mpga, m4a, wav, webm)
@@ -107,9 +110,15 @@ export class WhisperTranscriptionService implements ITranscriptionService {
 
     if (fileSize > WHISPER_MAX_SIZE) {
       const maxSizeMB = WHISPER_MAX_SIZE / (1024 * 1024);
-      throw new Error(
-        `Segment size exceeds the maximum allowed size of ${maxSizeMB}MB.`,
-      );
+      // Tagged permanent so the chunked retry loop fails fast instead of
+      // re-sending a chunk that can never fit under the API limit. Worded
+      // for end users, who never created "segments" themselves.
+      const sizeError = new Error(
+        `Part of this recording came out larger than the ${maxSizeMB}MB transcription limit. ` +
+          `Please try a shorter recording.`,
+      ) as TranscriptionError;
+      sizeError.errorClass = 'permanent';
+      throw sizeError;
     }
 
     try {

--- a/lib/services/transcriptionService.ts
+++ b/lib/services/transcriptionService.ts
@@ -15,7 +15,11 @@ export type TranscriptionServiceType = 'whisper' | 'batch';
  *
  * Routes transcription requests based on file size:
  * - Files ≤25MB: Whisper (synchronous)
- * - Files >25MB: Azure Speech Batch (asynchronous)
+ * - Files >25MB: Azure Speech Batch (asynchronous) — DEPRECATED, used only
+ *   by the legacy /api/file/[id]/transcribe route. The chat pipeline
+ *   (FileProcessor) handles >25MB files with ChunkedTranscriptionService
+ *   (ffmpeg split → parallel Whisper) instead; see
+ *   lib/services/transcription/chunkedTranscriptionService.ts.
  */
 export class TranscriptionServiceFactory {
   /**

--- a/lib/utils/server/audio/audioExtractor.ts
+++ b/lib/utils/server/audio/audioExtractor.ts
@@ -148,7 +148,43 @@ function getFfprobePath(): string | null {
     }
   }
 
-  // Strategy 3: Fall back to system ffprobe in PATH
+  // Strategy 3: Try the bundled ffprobe-static binary (per-platform layout;
+  // present wherever `npm ci` ran, so deploys don't silently depend on a
+  // system ffprobe)
+  const ffprobeStaticRelative = path.join(
+    'ffprobe-static',
+    'bin',
+    process.platform,
+    process.arch,
+    process.platform === 'win32' ? 'ffprobe.exe' : 'ffprobe',
+  );
+  try {
+    const npmRoot = execSync('npm root', { encoding: 'utf8' }).trim();
+    const staticPath = path.join(npmRoot, ffprobeStaticRelative);
+    if (fs.existsSync(staticPath)) {
+      console.log(
+        `[AudioExtractor] Using FFprobe from ffprobe-static: ${staticPath}`,
+      );
+      resolvedFfprobePath = staticPath;
+      return staticPath;
+    }
+  } catch {
+    // npm root command failed
+  }
+  const cwdStaticPath = path.join(
+    process.cwd(),
+    'node_modules',
+    ffprobeStaticRelative,
+  );
+  if (fs.existsSync(cwdStaticPath)) {
+    console.log(
+      `[AudioExtractor] Using FFprobe from ffprobe-static: ${cwdStaticPath}`,
+    );
+    resolvedFfprobePath = cwdStaticPath;
+    return cwdStaticPath;
+  }
+
+  // Strategy 4: Fall back to system ffprobe in PATH
   try {
     const whichResult = execSync('which ffprobe', { encoding: 'utf8' }).trim();
     if (whichResult) {

--- a/lib/utils/server/audio/audioSplitter.ts
+++ b/lib/utils/server/audio/audioSplitter.ts
@@ -168,6 +168,13 @@ export interface SplitOptions {
 const DEFAULT_TARGET_CHUNK_SIZE = 20 * 1024 * 1024;
 
 /**
+ * Bitrate used when re-encoding chunks to mp3/m4a. Shared between the
+ * segment-duration math and the ffmpeg invocation so they cannot drift —
+ * chunk size on disk is a function of THIS rate, not the input file's rate.
+ */
+const CHUNK_AUDIO_BITRATE_KBPS = 128;
+
+/**
  * Gets the duration of an audio file in seconds using ffprobe.
  *
  * @param inputPath - Path to the audio file
@@ -253,29 +260,54 @@ export async function getAudioBitrate(inputPath: string): Promise<number> {
 }
 
 /**
- * Calculates the optimal segment duration to achieve the target chunk size.
+ * Bytes per second of the RE-ENCODED chunks. Chunk size on disk depends only
+ * on the output encoding — using the input file's rate here is wrong: a
+ * low-bitrate input (e.g. a 64 kbps iPhone Voice Memo) re-encoded at 128 kbps
+ * would produce chunks ~2x the target, blowing past the Whisper size limit.
+ */
+async function getOutputBytesPerSecond(
+  outputFormat: 'mp3' | 'wav' | 'm4a',
+  inputPath: string,
+): Promise<number> {
+  if (outputFormat === 'mp3' || outputFormat === 'm4a') {
+    return (CHUNK_AUDIO_BITRATE_KBPS * 1000) / 8;
+  }
+
+  // wav (pcm_s16le): rate is sampleRate * channels * 2 bytes, taken from the
+  // input's audio stream since pcm preserves both.
+  return new Promise((resolve) => {
+    ffmpeg.ffprobe(inputPath, (err, metadata) => {
+      const audioStream = metadata?.streams?.find(
+        (s) => s.codec_type === 'audio',
+      );
+      const sampleRate = Number(audioStream?.sample_rate) || 44100;
+      const channels = Number(audioStream?.channels) || 2;
+      if (err) {
+        resolve(44100 * 2 * 2);
+        return;
+      }
+      resolve(sampleRate * channels * 2);
+    });
+  });
+}
+
+/**
+ * Calculates the optimal segment duration to achieve the target chunk size,
+ * based on the output encoding rate (chunks are re-encoded, so the input
+ * file's bitrate is irrelevant to how large they end up on disk).
  *
  * @param inputPath - Path to the audio file
  * @param targetSizeBytes - Target size for each chunk in bytes
+ * @param outputFormat - Format the chunks will be encoded to
  * @returns Segment duration in seconds
  */
 async function calculateSegmentDuration(
   inputPath: string,
   targetSizeBytes: number,
+  outputFormat: 'mp3' | 'wav' | 'm4a',
 ): Promise<number> {
-  const stats = await stat(inputPath);
-  const fileSize = stats.size;
+  const bytesPerSecond = await getOutputBytesPerSecond(outputFormat, inputPath);
 
-  const duration = await getAudioDuration(inputPath);
-
-  if (!Number.isFinite(duration) || duration <= 0) {
-    throw new Error('Audio has unusable duration');
-  }
-
-  // Calculate bytes per second
-  const bytesPerSecond = fileSize / duration;
-
-  // Calculate segment duration to achieve target size
   // Round down to be conservative (better to have more chunks than exceed size limit)
   const segmentDuration = Math.floor(targetSizeBytes / bytesPerSecond);
 
@@ -286,8 +318,9 @@ async function calculateSegmentDuration(
 /**
  * Splits an audio file into smaller chunks using FFmpeg segment feature.
  *
- * Uses stream copy (-c copy) for fast, lossless splitting when possible.
- * Falls back to re-encoding if stream copy fails.
+ * Chunks are always re-encoded (mp3/m4a at CHUNK_AUDIO_BITRATE_KBPS, wav as
+ * pcm_s16le) — stream copy can't cut at arbitrary points reliably across
+ * input containers.
  *
  * @param inputPath - Path to the input audio file
  * @param options - Split options (target size, format, output directory)
@@ -337,6 +370,7 @@ export async function splitAudioFile(
   let segmentDuration = await calculateSegmentDuration(
     inputPath,
     targetChunkSizeBytes,
+    outputFormat,
   );
   let estimatedChunks = Math.ceil(totalDuration / segmentDuration);
 
@@ -445,14 +479,14 @@ async function runSegmentation(
     switch (outputFormat) {
       case 'mp3':
         command.audioCodec('libmp3lame');
-        command.audioBitrate(128);
+        command.audioBitrate(CHUNK_AUDIO_BITRATE_KBPS);
         break;
       case 'wav':
         command.audioCodec('pcm_s16le');
         break;
       case 'm4a':
         command.audioCodec('aac');
-        command.audioBitrate(128);
+        command.audioBitrate(CHUNK_AUDIO_BITRATE_KBPS);
         break;
     }
 

--- a/lib/utils/server/audio/audioSplitter.ts
+++ b/lib/utils/server/audio/audioSplitter.ts
@@ -217,6 +217,18 @@ export interface SplitOptions {
 const DEFAULT_TARGET_CHUNK_SIZE = 20 * 1024 * 1024;
 
 /**
+ * Allowed shape for jobId before it is joined into a tmpdir path. All
+ * current callers pass UUIDs (or UUID-suffixed test ids); enforcing it here
+ * makes path safety a property of this module instead of of its callers.
+ */
+const SAFE_JOB_ID_REGEX = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
+
+/** Escapes regex metacharacters so a filename can be embedded in a RegExp. */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
  * Ceiling bitrate when re-encoding chunks to mp3/m4a. The actual rate is the
  * input's bitrate clamped to this (see resolveChunkEncoding) and feeds both
  * the segment-duration math and the ffmpeg invocation so they cannot drift —
@@ -439,6 +451,10 @@ export async function splitAudioFile(
     jobId,
   } = options;
 
+  if (jobId && !SAFE_JOB_ID_REGEX.test(jobId)) {
+    throw new Error('Invalid jobId for audio splitting');
+  }
+
   // Get file info
   const stats = await stat(inputPath);
   const fileSize = stats.size;
@@ -448,11 +464,38 @@ export async function splitAudioFile(
     throw new Error('Audio has unusable duration');
   }
 
+  const inputBasename = path.basename(inputPath, path.extname(inputPath));
+
   // If file is small enough, no splitting needed
   if (fileSize <= targetChunkSizeBytes) {
     console.log(
       `[AudioSplitter] File size (${(fileSize / 1024 / 1024).toFixed(1)}MB) is within target, no splitting needed`,
     );
+
+    // When the caller asked for managed output (jobId/outputDir), the single
+    // "chunk" must still be OUR copy: callers treat every returned chunkPath
+    // as disposable (cleanupChunks deletes them), and handing back the
+    // caller's input file would let that cleanup destroy it.
+    if (jobId || outputDir) {
+      const singleChunkDir =
+        outputDir ?? path.join(tmpdir(), 'chunked-transcription', jobId!);
+      await fs.promises.mkdir(singleChunkDir, { recursive: true });
+      const extension = path.extname(inputPath) || `.${outputFormat}`;
+      const singleChunkPath = path.join(
+        singleChunkDir,
+        `${inputBasename}_chunk_000${extension}`,
+      );
+      await fs.promises.copyFile(inputPath, singleChunkPath);
+      return {
+        chunkPaths: [singleChunkPath],
+        chunkCount: 1,
+        totalDurationSecs: totalDuration,
+        chunkDurationSecs: totalDuration,
+      };
+    }
+
+    // Legacy unmanaged mode: the input itself is returned. Callers in this
+    // mode must NOT pass the result to cleanupChunks.
     return {
       chunkPaths: [inputPath],
       chunkCount: 1,
@@ -500,7 +543,6 @@ export async function splitAudioFile(
   // Prepare output path pattern.
   // Prefer a per-job subdir under tmpdir when jobId is provided so parallel
   // jobs don't share a directory and cleanup can rm-rf the whole subdir.
-  const inputBasename = path.basename(inputPath, path.extname(inputPath));
   const outputDirectory =
     outputDir ||
     (jobId
@@ -648,7 +690,11 @@ async function findChunkFiles(
   format: string,
 ): Promise<string[]> {
   const files = await readdir(directory);
-  const pattern = new RegExp(`^${baseName}_chunk_\\d{3}\\.${format}$`);
+  // Escape both interpolated parts: a basename containing regex
+  // metacharacters (e.g. "take.1") must match literally, not as a pattern.
+  const pattern = new RegExp(
+    `^${escapeRegExp(baseName)}_chunk_\\d{3}\\.${escapeRegExp(format)}$`,
+  );
 
   const chunkFiles = files
     .filter((f) => pattern.test(f))

--- a/lib/utils/server/audio/audioSplitter.ts
+++ b/lib/utils/server/audio/audioSplitter.ts
@@ -86,6 +86,22 @@ function getFfmpegPath(): string | null {
 }
 
 /**
+ * Path of the ffprobe binary inside the ffprobe-static package, relative to
+ * node_modules. ffprobe-static ships per-platform binaries (unlike
+ * ffmpeg-static, which exposes a single top-level binary).
+ */
+function ffprobeStaticRelativePath(): string {
+  const binary = process.platform === 'win32' ? 'ffprobe.exe' : 'ffprobe';
+  return path.join(
+    'ffprobe-static',
+    'bin',
+    process.platform,
+    process.arch,
+    binary,
+  );
+}
+
+/**
  * Resolves the FFprobe binary path.
  * FFprobe is used to get audio file metadata (duration, bitrate).
  */
@@ -113,7 +129,36 @@ function getFfprobePath(): string | null {
     }
   }
 
-  // Strategy 3: Fall back to system ffprobe
+  // Strategy 3: Try npm root + ffprobe-static (bundled per-platform binary,
+  // present wherever `npm ci` ran — keeps tests and deploys from silently
+  // depending on a system ffprobe)
+  try {
+    const npmRoot = execSync('npm root', { encoding: 'utf8' }).trim();
+    const staticPath = path.join(npmRoot, ffprobeStaticRelativePath());
+    if (fs.existsSync(staticPath)) {
+      resolvedFfprobePath = staticPath;
+      return staticPath;
+    }
+  } catch {
+    // npm root command failed
+  }
+
+  // Strategy 4: Try process.cwd() based ffprobe-static path
+  try {
+    const cwdPath = path.join(
+      process.cwd(),
+      'node_modules',
+      ffprobeStaticRelativePath(),
+    );
+    if (fs.existsSync(cwdPath)) {
+      resolvedFfprobePath = cwdPath;
+      return cwdPath;
+    }
+  } catch {
+    // cwd approach failed
+  }
+
+  // Strategy 5: Fall back to system ffprobe
   try {
     const whichResult = execSync('which ffprobe', { encoding: 'utf8' }).trim();
     if (whichResult) {
@@ -172,9 +217,10 @@ export interface SplitOptions {
 const DEFAULT_TARGET_CHUNK_SIZE = 20 * 1024 * 1024;
 
 /**
- * Bitrate used when re-encoding chunks to mp3/m4a. Shared between the
- * segment-duration math and the ffmpeg invocation so they cannot drift —
- * chunk size on disk is a function of THIS rate, not the input file's rate.
+ * Ceiling bitrate when re-encoding chunks to mp3/m4a. The actual rate is the
+ * input's bitrate clamped to this (see resolveChunkEncoding) and feeds both
+ * the segment-duration math and the ffmpeg invocation so they cannot drift —
+ * chunk size on disk is a function of the OUTPUT rate, not the input file's.
  */
 const CHUNK_AUDIO_BITRATE_KBPS = 128;
 
@@ -264,54 +310,99 @@ export async function getAudioBitrate(inputPath: string): Promise<number> {
 }
 
 /**
- * Bytes per second of the RE-ENCODED chunks. Chunk size on disk depends only
- * on the output encoding — using the input file's rate here is wrong: a
- * low-bitrate input (e.g. a 64 kbps iPhone Voice Memo) re-encoded at 128 kbps
- * would produce chunks ~2x the target, blowing past the Whisper size limit.
+ * How the chunks will be encoded. Resolved once per split so the
+ * segment-duration math and the ffmpeg invocation use the same numbers.
  */
-async function getOutputBytesPerSecond(
+interface ChunkEncoding {
+  /** Bytes per second the encoded chunks occupy on disk (drives chunk sizing) */
+  bytesPerSecond: number;
+  /** Bitrate passed to ffmpeg for mp3/m4a chunks; undefined for pcm wav */
+  bitrateKbps?: number;
+}
+
+/**
+ * CBR bitrates libmp3lame actually supports within our clamp range, in kbps.
+ * lame silently rounds other values to this table, so picking from it keeps
+ * the size math in lockstep with what the encoder really produces. AAC has
+ * no such restriction but accepts these values fine.
+ */
+const MP3_CBR_BITRATES_KBPS = [32, 40, 48, 56, 64, 80, 96, 112, 128];
+
+/** Smallest bitrate we'll encode chunks at — Whisper needs intelligible speech. */
+const MIN_CHUNK_AUDIO_BITRATE_KBPS = MP3_CBR_BITRATES_KBPS[0];
+
+/**
+ * Resolves the chunk encoding for a split. Chunk size on disk depends only
+ * on the OUTPUT encoding — sizing segments from the input file's rate was
+ * the issue #57 bug (a 64 kbps iPhone Voice Memo re-encoded at 128 kbps
+ * produced chunks ~2x the target, blowing past the Whisper size limit).
+ *
+ * For mp3/m4a the bitrate is clamped to the input's: re-encoding above the
+ * source rate gains no quality and would double the bytes shipped to Whisper
+ * for low-bitrate sources. The clamped value is rounded UP to a valid CBR
+ * step so the encoder can't outrun the math.
+ */
+async function resolveChunkEncoding(
   outputFormat: 'mp3' | 'wav' | 'm4a',
   inputPath: string,
-): Promise<number> {
+): Promise<ChunkEncoding> {
   if (outputFormat === 'mp3' || outputFormat === 'm4a') {
-    return (CHUNK_AUDIO_BITRATE_KBPS * 1000) / 8;
+    let inputKbps = CHUNK_AUDIO_BITRATE_KBPS;
+    try {
+      inputKbps = Math.ceil((await getAudioBitrate(inputPath)) / 1000);
+    } catch (error) {
+      console.warn(
+        `[AudioSplitter] Could not probe input bitrate; encoding chunks at ` +
+          `${CHUNK_AUDIO_BITRATE_KBPS} kbps:`,
+        error instanceof Error ? error.message : error,
+      );
+    }
+
+    const clamped = Math.min(
+      CHUNK_AUDIO_BITRATE_KBPS,
+      Math.max(MIN_CHUNK_AUDIO_BITRATE_KBPS, inputKbps),
+    );
+    const bitrateKbps =
+      MP3_CBR_BITRATES_KBPS.find((standard) => standard >= clamped) ??
+      CHUNK_AUDIO_BITRATE_KBPS;
+
+    return { bytesPerSecond: (bitrateKbps * 1000) / 8, bitrateKbps };
   }
 
   // wav (pcm_s16le): rate is sampleRate * channels * 2 bytes, taken from the
   // input's audio stream since pcm preserves both.
   return new Promise((resolve) => {
     ffmpeg.ffprobe(inputPath, (err, metadata) => {
+      if (err) {
+        console.warn(
+          `[AudioSplitter] Could not probe input stream for wav chunk sizing; ` +
+            `assuming 44.1kHz stereo: ${err.message}`,
+        );
+        resolve({ bytesPerSecond: 44100 * 2 * 2 });
+        return;
+      }
       const audioStream = metadata?.streams?.find(
         (s) => s.codec_type === 'audio',
       );
       const sampleRate = Number(audioStream?.sample_rate) || 44100;
       const channels = Number(audioStream?.channels) || 2;
-      if (err) {
-        resolve(44100 * 2 * 2);
-        return;
-      }
-      resolve(sampleRate * channels * 2);
+      resolve({ bytesPerSecond: sampleRate * channels * 2 });
     });
   });
 }
 
 /**
  * Calculates the optimal segment duration to achieve the target chunk size,
- * based on the output encoding rate (chunks are re-encoded, so the input
- * file's bitrate is irrelevant to how large they end up on disk).
+ * based on the resolved output encoding rate.
  *
- * @param inputPath - Path to the audio file
  * @param targetSizeBytes - Target size for each chunk in bytes
- * @param outputFormat - Format the chunks will be encoded to
+ * @param bytesPerSecond - On-disk rate of the encoded chunks
  * @returns Segment duration in seconds
  */
-async function calculateSegmentDuration(
-  inputPath: string,
+function calculateSegmentDuration(
   targetSizeBytes: number,
-  outputFormat: 'mp3' | 'wav' | 'm4a',
-): Promise<number> {
-  const bytesPerSecond = await getOutputBytesPerSecond(outputFormat, inputPath);
-
+  bytesPerSecond: number,
+): number {
   // Round down to be conservative (better to have more chunks than exceed size limit)
   const segmentDuration = Math.floor(targetSizeBytes / bytesPerSecond);
 
@@ -322,9 +413,9 @@ async function calculateSegmentDuration(
 /**
  * Splits an audio file into smaller chunks using FFmpeg segment feature.
  *
- * Chunks are always re-encoded (mp3/m4a at CHUNK_AUDIO_BITRATE_KBPS, wav as
- * pcm_s16le) — stream copy can't cut at arbitrary points reliably across
- * input containers.
+ * Chunks are always re-encoded (mp3/m4a at the input's bitrate capped at
+ * CHUNK_AUDIO_BITRATE_KBPS, wav as pcm_s16le) — stream copy can't cut at
+ * arbitrary points reliably across input containers.
  *
  * @param inputPath - Path to the input audio file
  * @param options - Split options (target size, format, output directory)
@@ -370,11 +461,14 @@ export async function splitAudioFile(
     };
   }
 
+  // Resolve the output encoding once; it drives both the segment-duration
+  // math and the ffmpeg invocation below.
+  const encoding = await resolveChunkEncoding(outputFormat, inputPath);
+
   // Calculate segment duration
-  let segmentDuration = await calculateSegmentDuration(
-    inputPath,
+  let segmentDuration = calculateSegmentDuration(
     targetChunkSizeBytes,
-    outputFormat,
+    encoding.bytesPerSecond,
   );
   let estimatedChunks = Math.ceil(totalDuration / segmentDuration);
 
@@ -384,10 +478,12 @@ export async function splitAudioFile(
   // trade-off is individual chunks can then exceed targetChunkSizeBytes;
   // the post-split size check below catches any chunk that grew past the
   // Whisper cap and fails the job with a clear, non-retryable error rather
-  // than letting every chunk bounce off the Whisper API. At 128 kbps this
-  // only triggers past ~21 hours of audio.
+  // than letting every chunk bounce off the Whisper API. At the 128 kbps
+  // ceiling this means ~21+ hours of audio; lower-bitrate chunks stretch it
+  // further.
   const MAX_CHUNKS = 60;
-  if (estimatedChunks > MAX_CHUNKS) {
+  const cappedByMaxChunks = estimatedChunks > MAX_CHUNKS;
+  if (cappedByMaxChunks) {
     segmentDuration = Math.ceil(totalDuration / MAX_CHUNKS);
     estimatedChunks = Math.ceil(totalDuration / segmentDuration);
     console.warn(
@@ -397,7 +493,8 @@ export async function splitAudioFile(
 
   console.log(
     `[AudioSplitter] Splitting ${(fileSize / 1024 / 1024).toFixed(1)}MB file ` +
-      `(${totalDuration.toFixed(0)}s) into ~${estimatedChunks} chunks of ~${segmentDuration}s each`,
+      `(${totalDuration.toFixed(0)}s) into ~${estimatedChunks} chunks of ~${segmentDuration}s each` +
+      (encoding.bitrateKbps ? ` at ${encoding.bitrateKbps} kbps` : ''),
   );
 
   // Prepare output path pattern.
@@ -423,6 +520,7 @@ export async function splitAudioFile(
     outputPattern,
     segmentDuration,
     outputFormat,
+    encoding.bitrateKbps,
   );
 
   // Find all generated chunk files
@@ -438,17 +536,24 @@ export async function splitAudioFile(
 
   // Defense in depth: a chunk larger than the Whisper limit can never be
   // transcribed, so fail the whole job here with an actionable message
-  // instead of letting the API reject chunk after chunk. Only reachable via
-  // the MAX_CHUNKS cap above (extremely long recordings).
+  // instead of letting the API reject chunk after chunk. Reachable via the
+  // MAX_CHUNKS cap above (extremely long recordings) or, for wav output,
+  // via the 60s minimum segment duration on dense pcm streams — so only
+  // diagnose "too long" when the cap is actually what stretched the chunks.
   const chunkStats = await Promise.all(chunkPaths.map((p) => stat(p)));
   const oversized = chunkStats.find((s) => s.size > WHISPER_MAX_SIZE);
   if (oversized) {
     await cleanupChunks(chunkPaths);
+    const limitMB = Math.floor(WHISPER_MAX_SIZE / (1024 * 1024));
     const totalHours = (totalDuration / 3600).toFixed(1);
-    const error = new Error(
-      `This recording is too long to transcribe (~${totalHours} hours of audio). ` +
-        `Please split it into shorter parts and try again.`,
-    ) as TranscriptionError;
+    const oversizedMB = (oversized.size / (1024 * 1024)).toFixed(1);
+    const message = cappedByMaxChunks
+      ? `This recording is too long to transcribe (~${totalHours} hours of audio). ` +
+        `Please split it into shorter parts and try again.`
+      : `This recording could not be split into pieces small enough to transcribe ` +
+        `(a ${oversizedMB}MB piece exceeds the ${limitMB}MB limit). ` +
+        `Please try a shorter or lower-quality recording.`;
+    const error = new Error(message) as TranscriptionError;
     error.errorClass = 'permanent';
     throw error;
   }
@@ -477,6 +582,7 @@ async function runSegmentation(
   outputPattern: string,
   segmentDuration: number,
   outputFormat: string,
+  bitrateKbps: number = CHUNK_AUDIO_BITRATE_KBPS,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     // Ring buffer: newest ffmpeg stderr line pushes the oldest out once the
@@ -500,14 +606,14 @@ async function runSegmentation(
     switch (outputFormat) {
       case 'mp3':
         command.audioCodec('libmp3lame');
-        command.audioBitrate(CHUNK_AUDIO_BITRATE_KBPS);
+        command.audioBitrate(bitrateKbps);
         break;
       case 'wav':
         command.audioCodec('pcm_s16le');
         break;
       case 'm4a':
         command.audioCodec('aac');
-        command.audioBitrate(CHUNK_AUDIO_BITRATE_KBPS);
+        command.audioBitrate(bitrateKbps);
         break;
     }
 

--- a/lib/utils/server/audio/audioSplitter.ts
+++ b/lib/utils/server/audio/audioSplitter.ts
@@ -5,6 +5,10 @@
  * This module works alongside audioExtractor.ts and uses the same
  * FFmpeg path resolution strategy.
  */
+import { WHISPER_MAX_SIZE } from '@/lib/utils/app/const';
+
+import { TranscriptionError } from '@/types/transcription';
+
 import { execSync } from 'child_process';
 import ffmpeg from 'fluent-ffmpeg';
 import fs from 'fs';
@@ -377,11 +381,11 @@ export async function splitAudioFile(
   // Cap chunk count so pathologically long audio doesn't spray hundreds of
   // chunks into tmpdir and the Whisper queue. If we'd exceed the cap, grow
   // segmentDuration so the whole file fits in MAX_CHUNKS segments. The
-  // trade-off is individual chunks can then exceed targetChunkSizeBytes; if
-  // any chunk grows past Whisper's 25MB cap, transcription of that chunk
-  // will fail permanently. There is no re-split-on-size retry today — if
-  // that becomes a real problem in practice, add one in chunkedTranscription-
-  // Service or lower MAX_CHUNKS.
+  // trade-off is individual chunks can then exceed targetChunkSizeBytes;
+  // the post-split size check below catches any chunk that grew past the
+  // Whisper cap and fails the job with a clear, non-retryable error rather
+  // than letting every chunk bounce off the Whisper API. At 128 kbps this
+  // only triggers past ~21 hours of audio.
   const MAX_CHUNKS = 60;
   if (estimatedChunks > MAX_CHUNKS) {
     segmentDuration = Math.ceil(totalDuration / MAX_CHUNKS);
@@ -430,6 +434,23 @@ export async function splitAudioFile(
 
   if (chunkPaths.length === 0) {
     throw new Error('No chunk files were generated');
+  }
+
+  // Defense in depth: a chunk larger than the Whisper limit can never be
+  // transcribed, so fail the whole job here with an actionable message
+  // instead of letting the API reject chunk after chunk. Only reachable via
+  // the MAX_CHUNKS cap above (extremely long recordings).
+  const chunkStats = await Promise.all(chunkPaths.map((p) => stat(p)));
+  const oversized = chunkStats.find((s) => s.size > WHISPER_MAX_SIZE);
+  if (oversized) {
+    await cleanupChunks(chunkPaths);
+    const totalHours = (totalDuration / 3600).toFixed(1);
+    const error = new Error(
+      `This recording is too long to transcribe (~${totalHours} hours of audio). ` +
+        `Please split it into shorter parts and try again.`,
+    ) as TranscriptionError;
+    error.errorClass = 'permanent';
+    throw error;
   }
 
   console.log(

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "@tiptap/starter-kit": "^3.10.2",
         "@vercel/otel": "^2.1.0",
         "ffmpeg-static": "^5.3.0",
+        "ffprobe-static": "^3.1.0",
         "fluent-ffmpeg": "^2.1.3",
         "he": "^1.2.0",
         "html-to-docx": "^1.8.0",
@@ -10419,6 +10420,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/ffprobe-static": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ffprobe-static/-/ffprobe-static-3.1.0.tgz",
+      "integrity": "sha512-Dvpa9uhVMOYivhHKWLGDoa512J751qN1WZAIO+Xw4L/mrUSPxS4DApzSUDbCFE/LUq2+xYnznEahTd63AqBSpA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@tiptap/starter-kit": "^3.10.2",
     "@vercel/otel": "^2.1.0",
     "ffmpeg-static": "^5.3.0",
+    "ffprobe-static": "^3.1.0",
     "fluent-ffmpeg": "^2.1.3",
     "he": "^1.2.0",
     "html-to-docx": "^1.8.0",

--- a/types/transcription.ts
+++ b/types/transcription.ts
@@ -131,4 +131,10 @@ export type TranscriptionErrorClass =
 
 export interface TranscriptionError extends Error {
   errorClass: TranscriptionErrorClass;
+  /**
+   * Server-suggested wait before retrying, in seconds. Only set for
+   * `rate_limit` errors where the API communicated a Retry-After; retry
+   * loops should prefer this over their own backoff schedule.
+   */
+  retryAfterSeconds?: number;
 }


### PR DESCRIPTION
This attempts to fix a lot of bugs with transcription, though primarily a re-encoding bug.

The issue is that iphones record at a certain bitrate, which if >25mb will get split because the API doesn't support that. Unfortunately the splitting also raises the bitrate (without gaining extra quality of course) so the resultant, split files are also always larger than the maximum.

I've capped bitrate to be at most as much as the input file to prevent this expansion and also better piped those errors into the chat context so the response messages are not as nonsensical.

Other fixes include:

- A lot around file cleanup
- Similar amounts on making sure files would never conflict (this hasn't happened to my knowledge, but was possible)
- Improvements to parallelization of requests when splits occur
- Code cleanup (dead code, minor refactors)

One unrelated fix: our fallback model logic didn't account for issues with the default model, which I experienced today. So this code also splits the concept of default model from fallback model. I've also added a fallback chain, so if one model fails, we will try again with a few more. This should make it more robust so that failures will have to be general in order to really affect the user beyond delays.