### PR TITLE
hotfix: empty state for agents

### DIFF
--- a/__tests__/components/Chat/ModelSelect.test.tsx
+++ b/__tests__/components/Chat/ModelSelect.test.tsx
@@ -7,6 +7,7 @@ import { SearchMode } from '@/types/searchMode';
 
 import { ModelSelect } from '@/components/Chat/ModelSelect';
 
+import { useSettingsStore } from '@/client/stores/settingsStore';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock the hooks
@@ -36,6 +37,24 @@ const mockUseCustomAgents = {
   deleteCustomAgent: vi.fn(),
 };
 
+// Mutable LaunchDarkly flags — empty by default (so `exploreBots` is undefined
+// and treated as enabled). Individual tests can flip `exploreBots` to false.
+const mockFlags: Record<string, unknown> = {};
+
+// Mutable Foundry discovery result so tests can inject discovered agents.
+const mockFoundryAgents = {
+  foundryAgents: [] as Array<Record<string, unknown>>,
+  regionalPath: null as string | null,
+  officePaths: [] as string[],
+  isLoadingFoundryAgents: false,
+  foundryAgentsError: null,
+  refetchFoundryAgents: vi.fn(),
+};
+
+vi.mock('launchdarkly-react-client-sdk', () => ({
+  useFlags: () => mockFlags,
+}));
+
 vi.mock('@/client/hooks/conversation/useConversations', () => ({
   useConversations: () => mockUseConversations,
 }));
@@ -49,14 +68,7 @@ vi.mock('@/client/hooks/settings/useCustomAgents', () => ({
 }));
 
 vi.mock('@/client/hooks/settings/useFoundryAgents', () => ({
-  useFoundryAgents: () => ({
-    foundryAgents: [],
-    regionalPath: null,
-    officePaths: [],
-    isLoadingFoundryAgents: false,
-    foundryAgentsError: null,
-    refetchFoundryAgents: vi.fn(),
-  }),
+  useFoundryAgents: () => mockFoundryAgents,
 }));
 
 // Note: next-intl is mocked globally in vitest.setup.dom.ts
@@ -64,6 +76,13 @@ vi.mock('@/client/hooks/settings/useFoundryAgents', () => ({
 describe('ModelSelect', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+
+    // Reset mutable mocks back to defaults (flag on, no discovered agents).
+    for (const key of Object.keys(mockFlags)) delete mockFlags[key];
+    mockFoundryAgents.foundryAgents = [];
+    mockFoundryAgents.regionalPath = null;
+    mockFoundryAgents.officePaths = [];
+    useSettingsStore.setState({ customAgentSources: [] });
 
     // Reset mock data
     mockUseConversations.selectedConversation = {
@@ -525,6 +544,75 @@ describe('ModelSelect', () => {
       // Should not have close button
       const xButtons = container.querySelectorAll('[aria-label="Close"]');
       expect(xButtons.length).toBe(0);
+    });
+  });
+
+  describe('BYO Foundry sources when discovery is disabled', () => {
+    it('keeps custom-source agents selectable but hides region agents when exploreBots is false', async () => {
+      mockFlags.exploreBots = false;
+
+      useSettingsStore.setState({
+        customAgentSources: [
+          {
+            id: 'src-1',
+            name: 'My Foundry Project',
+            resourcePath: '/subscriptions/x/custom-project',
+            createdAt: '2026-01-01T00:00:00.000Z',
+          },
+        ],
+      });
+
+      mockFoundryAgents.regionalPath = '/subscriptions/x/region-project';
+      mockFoundryAgents.foundryAgents = [
+        {
+          id: 'byo-1',
+          name: 'My BYO Agent',
+          agentName: 'asst_byo',
+          source: '/subscriptions/x/custom-project',
+          description: 'Agent from a user-connected project',
+        },
+        {
+          id: 'region-1',
+          name: 'Region Only Agent',
+          agentName: 'asst_region',
+          source: '/subscriptions/x/region-project',
+          description: 'Org-managed regional agent',
+        },
+      ];
+
+      render(<ModelSelect />);
+
+      // Switch to the Agents tab.
+      fireEvent.click(screen.getByText('Agents').closest('button')!);
+
+      // BYO custom-source agent is shown; the org-managed region agent is gated out.
+      const byoRow = await screen.findByText('My BYO Agent');
+      expect(byoRow).toBeInTheDocument();
+      expect(screen.queryByText('Region Only Agent')).not.toBeInTheDocument();
+
+      // Clicking the BYO agent actually selects it. This is the bug fix: before,
+      // organizationAgentModels was empty when the flag was off, so the click
+      // resolved to no model and did nothing.
+      fireEvent.click(byoRow.closest('button')!);
+      await waitFor(() => {
+        expect(mockUseConversations.updateConversation).toHaveBeenCalledWith(
+          'conv-1',
+          expect.objectContaining({
+            model: expect.objectContaining({
+              id: expect.stringContaining('foundry-'),
+            }),
+          }),
+        );
+      });
+    });
+
+    it('shows the empty state when discovery is off and no custom sources exist', () => {
+      mockFlags.exploreBots = false;
+
+      render(<ModelSelect />);
+      fireEvent.click(screen.getByText('Agents').closest('button')!);
+
+      expect(screen.getByText('No agents available')).toBeInTheDocument();
     });
   });
 });

--- a/__tests__/components/Chat/ModelSelect.test.tsx
+++ b/__tests__/components/Chat/ModelSelect.test.tsx
@@ -612,7 +612,9 @@ describe('ModelSelect', () => {
       render(<ModelSelect />);
       fireEvent.click(screen.getByText('Agents').closest('button')!);
 
-      expect(screen.getByText('No agents available')).toBeInTheDocument();
+      expect(
+        screen.getByText('No regional / organization agents available'),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/components/Chat/ModelSelect.tsx
+++ b/components/Chat/ModelSelect.tsx
@@ -191,13 +191,22 @@ export const ModelSelect: FC<ModelSelectProps> = ({ onClose }) => {
   // Convert organization agents to OpenAIModel format
   // Combines static RAG agents (from JSON config) with dynamically discovered Foundry agents
   const organizationAgentModels: OpenAIModel[] = useMemo(() => {
-    // Feature flag check: Skip organization agents if disabled in LaunchDarkly
-    if (!isBotsEnabled) {
-      return [];
-    }
+    // The `exploreBots` flag gates org-managed discovery (static org agents +
+    // region/office Foundry projects) — NOT the user's own connected sources.
+    // When the flag is off we still keep agents from custom (BYO) sources so
+    // users can use Foundry projects they connected themselves.
+    const customSourcePaths = new Set(
+      customAgentSources.map((s) => s.resourcePath),
+    );
+    const visibleFoundryAgents = isBotsEnabled
+      ? foundryAgents
+      : foundryAgents.filter(
+          (a) => a.source && customSourcePaths.has(a.source),
+        );
 
-    // Static agents from organization-agents.json (RAG agents + any static Foundry agents)
-    const staticAgents = getOrganizationAgents();
+    // Static agents from organization-agents.json (RAG agents + any static
+    // Foundry agents) are org-managed, so they're skipped when the flag is off.
+    const staticAgents = isBotsEnabled ? getOrganizationAgents() : [];
     const staticModels = staticAgents.map((agent) => {
       const baseModelId =
         (agent.baseModelId as OpenAIModelID) || OpenAIModelID.GPT_4_1;
@@ -218,7 +227,7 @@ export const ModelSelect: FC<ModelSelectProps> = ({ onClose }) => {
     // Model ID includes a short hash of the source path so the same-named agent
     // discovered from two different Foundry projects produces two distinct models
     // (otherwise React key collisions + ambiguous selection).
-    const dynamicModels = foundryAgents.map((agent) => {
+    const dynamicModels = visibleFoundryAgents.map((agent) => {
       const baseModel = OpenAIModels[OpenAIModelID.GPT_4_1];
       const sourceHash = shortSourceHash(agent.source);
       return {
@@ -237,13 +246,15 @@ export const ModelSelect: FC<ModelSelectProps> = ({ onClose }) => {
 
     // Deduplicate: if a Foundry agent exists in both static config and dynamic discovery,
     // prefer the dynamic version (it has RBAC validation)
-    const dynamicAgentNames = new Set(foundryAgents.map((a) => a.agentName));
+    const dynamicAgentNames = new Set(
+      visibleFoundryAgents.map((a) => a.agentName),
+    );
     const deduplicatedStatic = staticModels.filter(
       (m) => !m.agentId || !dynamicAgentNames.has(m.agentId),
     );
 
     return [...deduplicatedStatic, ...dynamicModels];
-  }, [isBotsEnabled, foundryAgents]);
+  }, [isBotsEnabled, foundryAgents, customAgentSources]);
 
   // Combine base models and organization/discovered agents
   const availableModels = useMemo(

--- a/components/Chat/ModelSelect/AgentsTab.tsx
+++ b/components/Chat/ModelSelect/AgentsTab.tsx
@@ -162,7 +162,6 @@ export const AgentsTab: FC<AgentsTabProps> = ({
 
   const organizationAgents = getOrganizationAgents();
   const isBotsEnabled = exploreBots !== false;
-  const hasOrganizationAgents = isBotsEnabled && organizationAgents.length > 0;
 
   // Region/office labels. Office name is user-defined config (place name), so it
   // isn't translated; the rest is.
@@ -194,7 +193,15 @@ export const AgentsTab: FC<AgentsTabProps> = ({
   );
   const getSourceAgents = (sourcePath: string) =>
     foundryAgents.filter((a) => a.source === sourcePath);
-  const hasOfficeSection = officeName != null && officeFoundryAgents.length > 0;
+  // Region/office org agents are gated by the discovery flag (exploreBots);
+  // custom (BYO) sources rendered below are not. The region section shows when
+  // there's any static org agent OR a discovered regional agent, so a
+  // discovery-only region isn't hidden just because it has no static agents.
+  const hasOrganizationAgents =
+    isBotsEnabled &&
+    (organizationAgents.length > 0 || regionalAgents.length > 0);
+  const hasOfficeSection =
+    isBotsEnabled && officeName != null && officeFoundryAgents.length > 0;
 
   // Stable model ID for a discovered Foundry agent — matches what ModelSelect
   // builds when constructing organizationAgentModels. Includes a source hash so
@@ -479,6 +486,25 @@ export const AgentsTab: FC<AgentsTabProps> = ({
               </section>
             );
           })}
+
+          {/* Empty state — nothing to show in any section. Keeps the Connect
+              button below as the call to action instead of leaving it bare. */}
+          {organizationAgentModels.length === 0 &&
+            agentSources.length === 0 && (
+              <div className="rounded-lg border border-dashed border-gray-300 dark:border-gray-700 px-4 py-6 text-center">
+                <IconHexagon
+                  size={24}
+                  className="mx-auto text-gray-300 dark:text-gray-600"
+                  aria-hidden="true"
+                />
+                <p className="mt-2 text-sm font-medium text-gray-600 dark:text-gray-300 leading-tight">
+                  {t('emptyState.title')}
+                </p>
+                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400 leading-snug">
+                  {t('emptyState.description')}
+                </p>
+              </div>
+            )}
 
           {/* Connect button */}
           <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">

--- a/messages/am.json
+++ b/messages/am.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "ቴክኒካዊ ዝርዝሮች",
       "agentCountLabel": "{count} ወኪሎች",
       "disconnectedToast": "{name} ከተገናኙ ተቋርጧል"
+    },
+    "emptyState": {
+      "title": "የክልል / የድርጅት ወኪሎች የሉም",
+      "description": "የ Foundry ፕሮጀክት ያገናኙ እና ዋና ወኪሎቹን ያግኙ።"
     }
   },
   "privacy": {

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "تفاصيل تقنية",
       "agentCountLabel": "{count} وكلاء",
       "disconnectedToast": "تم قطع الاتصال بـ {name}"
+    },
+    "emptyState": {
+      "title": "لا يوجد وكلاء إقليميون أو تنظيميونيون متاحون",
+      "description": "قم بربط مشروع Foundry أدناه لاكتشاف وكلائه."
     }
   },
   "privacy": {

--- a/messages/bn.json
+++ b/messages/bn.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "প্রযুক্তিগত বিবরণ",
       "agentCountLabel": "{count} এজেন্টস",
       "disconnectedToast": "{name} বিচ্ছিন্ন করা হয়েছে"
+    },
+    "emptyState": {
+      "title": "কোনো আঞ্চলিক / সংস্থাগত এজেন্ট উপলব্ধ নেই",
+      "description": "এর এজেন্টগুলো দেখতে নিচে একটি Foundry প্রকল্প সংযুক্ত করুন।"
     }
   },
   "privacy": {

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "Detalls tècnics",
       "agentCountLabel": "{count} agents",
       "disconnectedToast": "{name} desconnectat/da"
+    },
+    "emptyState": {
+      "title": "No hi ha agents regionals o organitzatius disponibles",
+      "description": "Connecteu un projecte de Foundry a continuació per descobrir-ne els agents."
     }
   },
   "privacy": {

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "Technické detaily",
       "agentCountLabel": "{count} agentů",
       "disconnectedToast": "Odpojeno {name}"
+    },
+    "emptyState": {
+      "title": "Nejsou dostupní žádní regionální ani organizační agenti",
+      "description": "Pro zobrazení agentů připojte níže projekt Foundry."
     }
   },
   "privacy": {

--- a/messages/de.json
+++ b/messages/de.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "Technische Details",
       "agentCountLabel": "{count} Agents",
       "disconnectedToast": "{name} getrennt"
+    },
+    "emptyState": {
+      "title": "Keine regionalen/organisatorischen Agenten verfügbar",
+      "description": "Verbinden Sie unten ein Foundry-Projekt, um dessen Agenten anzuzeigen."
     }
   },
   "privacy": {

--- a/messages/el.json
+++ b/messages/el.json
@@ -1975,6 +1975,10 @@
       "technicalDetails": "Τεχνικές λεπτομέρειες",
       "agentCountLabel": "{count} agents",
       "disconnectedToast": "Αποσυνδέθηκε το {name}"
+    },
+    "emptyState": {
+      "title": "Δεν υπάρχουν διαθέσιμοι περιφερειακοί / οργανωτικοί agents",
+      "description": "Συνδέστε ένα Foundry project παρακάτω για να δείτε τους agents του."
     }
   },
   "privacy": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -1956,6 +1956,10 @@
     },
     "selectAgentPrompt": "Select an agent to view details",
     "description": "Specialized AI agents for specific tasks. Default agents are managed centrally; add custom sources to discover agents from other Foundry projects.",
+    "emptyState": {
+      "title": "No regional / organizational agents available",
+      "description": "Connect a Foundry project below to discover its agents."
+    },
     "regionAgents": {
       "us": "US Region Agents",
       "eu": "EU Region Agents",

--- a/messages/es.json
+++ b/messages/es.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "Detalles técnicos",
       "agentCountLabel": "{count} agentes",
       "disconnectedToast": "{name} desconectado"
+    },
+    "emptyState": {
+      "title": "No hay agentes regionales u organizacionales disponibles",
+      "description": "Conecte un proyecto de Foundry a continuación para descubrir sus agentes."
     }
   },
   "privacy": {

--- a/messages/fa.json
+++ b/messages/fa.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "جزئیات فنی",
       "agentCountLabel": "{count} نماینده",
       "disconnectedToast": "{name} قطع اتصال شد"
+    },
+    "emptyState": {
+      "title": "هیچ نماینده منطقه‌ای یا سازمانی در دسترس نیست",
+      "description": "برای مشاهده نماینده‌ها، یک پروژه Foundry را در زیر متصل کنید."
     }
   },
   "privacy": {

--- a/messages/ff.json
+++ b/messages/ff.json
@@ -1975,6 +1975,10 @@
       "technicalDetails": "Carii teknikal",
       "agentCountLabel": "Agent {count}",
       "disconnectedToast": "Liggital toggo {name}"
+    },
+    "emptyState": {
+      "title": "Agentji dow nguu/ko organisation ngam hollude walaa",
+      "description": "Jokku e project Foundry ko ñaam kono waɗu agentjee mum."
     }
   },
   "privacy": {

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "Tekniset tiedot",
       "agentCountLabel": "{count} agenttia",
       "disconnectedToast": "Yhteys katkaistu: {name}"
+    },
+    "emptyState": {
+      "title": "Ei alueellisia tai organisatorisia agentteja saatavilla",
+      "description": "Yhdistä Foundry-projekti alta nähdäksesi sen agentit."
     }
   },
   "privacy": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "Détails techniques",
       "agentCountLabel": "{count} agents",
       "disconnectedToast": "{name} déconnecté"
+    },
+    "emptyState": {
+      "title": "Aucun agent régional ou organisationnel disponible",
+      "description": "Connectez un projet Foundry ci-dessous pour découvrir ses agents."
     }
   },
   "privacy": {

--- a/messages/ha.json
+++ b/messages/ha.json
@@ -1975,6 +1975,10 @@
       "technicalDetails": "Cikakkun bayanai na fasaha",
       "agentCountLabel": "wakilai {count}",
       "disconnectedToast": "An katse {name}"
+    },
+    "emptyState": {
+      "title": "Babu wakilai na yanki ko na ƙungiya a yanzu",
+      "description": "Haɗa da wani aikin Foundry a ƙasa don gano wakilansa."
     }
   },
   "privacy": {

--- a/messages/he.json
+++ b/messages/he.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "פרטים טכניים",
       "agentCountLabel": "{count} סוכנים",
       "disconnectedToast": "נותק {name}"
+    },
+    "emptyState": {
+      "title": "אין סוכנים אזוריים / ארגוניים זמינים",
+      "description": "חברו פרויקט Foundry למטה כדי לגלות את הסוכנים שלו."
     }
   },
   "privacy": {

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "तकनीकी विवरण",
       "agentCountLabel": "{count} एजेंट्स",
       "disconnectedToast": "{name} डिस्कनेक्ट किया गया"
+    },
+    "emptyState": {
+      "title": "कोई क्षेत्रीय / संगठनात्मक एजेंट उपलब्ध नहीं हैं",
+      "description": "इसके एजेंट देखने के लिए नीचे एक Foundry प्रोजेक्ट कनेक्ट करें।"
     }
   },
   "privacy": {

--- a/messages/ht.json
+++ b/messages/ht.json
@@ -1975,6 +1975,10 @@
       "technicalDetails": "Detay teknik",
       "agentCountLabel": "{count} ajan",
       "disconnectedToast": "Dekonekte {name}"
+    },
+    "emptyState": {
+      "title": "Pa gen ajan rejyonal / òganizasyonèl disponib",
+      "description": "Konekte yon pwojè Foundry anba a pou w dekouvri ajan li yo."
     }
   },
   "privacy": {

--- a/messages/id.json
+++ b/messages/id.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "Detail teknis",
       "agentCountLabel": "{count} agen",
       "disconnectedToast": "Terputus {name}"
+    },
+    "emptyState": {
+      "title": "Tidak ada agen regional / organisasi yang tersedia",
+      "description": "Hubungkan proyek Foundry di bawah ini untuk menemukan agennya."
     }
   },
   "privacy": {

--- a/messages/it.json
+++ b/messages/it.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "Dettagli tecnici",
       "agentCountLabel": "{count} agenti",
       "disconnectedToast": "{name} disconnesso"
+    },
+    "emptyState": {
+      "title": "Nessun agente regionale o organizzativo disponibile",
+      "description": "Collega un progetto Foundry qui sotto per scoprire i suoi agenti."
     }
   },
   "privacy": {

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "技術詳細",
       "agentCountLabel": "{count} エージェント",
       "disconnectedToast": "{name}の接続を解除しました"
+    },
+    "emptyState": {
+      "title": "利用可能な地域・組織エージェントはありません",
+      "description": "以下でFoundryプロジェクトを接続して、そのエージェントを確認してください。"
     }
   },
   "privacy": {

--- a/messages/km.json
+++ b/messages/km.json
@@ -1975,6 +1975,10 @@
       "technicalDetails": "ព័ត៌មានបច្ចេកទេស",
       "agentCountLabel": "ភ្នាក់ងារ {count} នាក់",
       "disconnectedToast": "បានផ្តាច់ {name}"
+    },
+    "emptyState": {
+      "title": "មិនមានភ្នាក់ងារតំបន់ ឬ ស្ថាប័នណាមួយដែលអាចប្រើបានទេ",
+      "description": "ភ្ជាប់គម្រោង Foundry ខាងក្រោម ដើម្បីស្វែងរកភ្នាក់ងាររបស់វា។"
     }
   },
   "privacy": {

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "기술 세부 정보",
       "agentCountLabel": "에이전트 {count}개",
       "disconnectedToast": "{name} 연결 해제됨"
+    },
+    "emptyState": {
+      "title": "사용 가능한 지역/기관 에이전트가 없습니다.",
+      "description": "아래에서 Foundry 프로젝트를 연결하여 에이전트를 확인하세요."
     }
   },
   "privacy": {

--- a/messages/ku.json
+++ b/messages/ku.json
@@ -1975,6 +1975,10 @@
       "technicalDetails": "وردەکاریی تەکنیکی",
       "agentCountLabel": "{count} وەکیل",
       "disconnectedToast": "دوورکرا لە {name}"
+    },
+    "emptyState": {
+      "title": "هیچ وەکی ناوچەیی/ڕێکخراوی بەردەست نییە",
+      "description": "پڕۆژەی Foundry لە خوارەوە بەستە بۆ دۆزینەوەی وەکەکانی."
     }
   },
   "privacy": {

--- a/messages/ln.json
+++ b/messages/ln.json
@@ -1975,6 +1975,10 @@
       "technicalDetails": "Makambo ya tekinike",
       "agentCountLabel": "{count} bato",
       "disconnectedToast": "Source {name} ekangi te"
+    },
+    "emptyState": {
+      "title": "Azali na agent moko te ya region to ya organisation",
+      "description": "Kopesa boyokani na projet ya Foundry na nse mpo omona ba agents na yango."
     }
   },
   "privacy": {

--- a/messages/mg.json
+++ b/messages/mg.json
@@ -1975,6 +1975,10 @@
       "technicalDetails": "Antsipiriany teknika",
       "agentCountLabel": "Agents {count}",
       "disconnectedToast": "Tapatra ny fifandraisana amin'i {name}"
+    },
+    "emptyState": {
+      "title": "Tsy misy solontena faritra na fikambanana azo ampiasaina",
+      "description": "Ampifandraiso amin'ny tetikasa Foundry etsy ambany raha hijery ny solontenany."
     }
   },
   "privacy": {

--- a/messages/my.json
+++ b/messages/my.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "နည်းပညာအသေးစိတ်",
       "agentCountLabel": "အေဂျင့် {count} ဦး",
       "disconnectedToast": "{name} ကိုဖြုတ်ပြီး"
+    },
+    "emptyState": {
+      "title": "ဒေသဆိုင်ရာ / အဖွဲ့အစည်းအေးဂျင့်များ မရှိပါ",
+      "description": "အေးဂျင့်များကို ရှာဖွေရန် Foundry project တစ်ခုကို အောက်တွင် ချိတ်ဆက်ပါ။"
     }
   },
   "privacy": {

--- a/messages/ne.json
+++ b/messages/ne.json
@@ -1975,6 +1975,10 @@
       "technicalDetails": "प्राविधिक विवरणहरू",
       "agentCountLabel": "{count} एजेन्टहरू",
       "disconnectedToast": "{name} छुट्यो"
+    },
+    "emptyState": {
+      "title": "क्षेत्रीय / संस्थागत एजेन्टहरू उपलब्ध छैनन्",
+      "description": "यसको एजेन्टहरू हेर्नको लागि तल Foundry परियोजना जडान गर्नुहोस्।"
     }
   },
   "privacy": {

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "Technische details",
       "agentCountLabel": "{count} agenten",
       "disconnectedToast": "Verbinding met {name} verbroken"
+    },
+    "emptyState": {
+      "title": "Geen regionale of organisatorische agenten beschikbaar",
+      "description": "Verbind hieronder een Foundry-project om de agenten te ontdekken."
     }
   },
   "privacy": {

--- a/messages/ny.json
+++ b/messages/ny.json
@@ -1975,6 +1975,10 @@
       "technicalDetails": "Zambiri zaukadaulo",
       "agentCountLabel": "Oimira {count}",
       "disconnectedToast": "Yadulidwa {name}"
+    },
+    "emptyState": {
+      "title": "Palibe othandizira m'dera kapena bungwe omwe alipo",
+      "description": "Lumikizani projekiti ya Foundry pansipa kuti muwone othandizira ake."
     }
   },
   "privacy": {

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "Szczegóły techniczne",
       "agentCountLabel": "{count} agentów",
       "disconnectedToast": "Odłączono {name}"
+    },
+    "emptyState": {
+      "title": "Brak dostępnych agentów regionalnych / organizacyjnych",
+      "description": "Połącz projekt Foundry poniżej, aby odkryć jego agentów."
     }
   },
   "privacy": {

--- a/messages/ps.json
+++ b/messages/ps.json
@@ -1975,6 +1975,10 @@
       "technicalDetails": "تخنیکي جزیات",
       "agentCountLabel": "{count} اجنټان",
       "disconnectedToast": "{name} بېل شو"
+    },
+    "emptyState": {
+      "title": "هیڅ سیمه‌ییز یا سازماني اجنټان نشته",
+      "description": "د اجنټانو د موندلو لپاره لاندې یو Foundry پروژه وصل کړئ."
     }
   },
   "privacy": {

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "Detalhes técnicos",
       "agentCountLabel": "{count} agentes",
       "disconnectedToast": "{name} desconectado"
+    },
+    "emptyState": {
+      "title": "Nenhum agente regional/organizacional disponível",
+      "description": "Conecte um projeto Foundry abaixo para descobrir seus agentes."
     }
   },
   "privacy": {

--- a/messages/rn.json
+++ b/messages/rn.json
@@ -1975,6 +1975,10 @@
       "technicalDetails": "Ibisobanuro vya tekinike",
       "agentCountLabel": "{count} abakozi",
       "disconnectedToast": "Vyavuye kuri {name}"
+    },
+    "emptyState": {
+      "title": "Nta bakozi bo mu karere canke ishirahamwe baboneka",
+      "description": "Huzaho umushinga wa Foundry hasi kugira ubone abakozi bawo."
     }
   },
   "privacy": {

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "Detalii tehnice",
       "agentCountLabel": "{count} agenți",
       "disconnectedToast": "{name} deconectat"
+    },
+    "emptyState": {
+      "title": "Nu există agenți regionali / organizaționali disponibili",
+      "description": "Conectați un proiect Foundry mai jos pentru a descoperi agenții acestuia."
     }
   },
   "privacy": {

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "Технические детали",
       "agentCountLabel": "{count} агентов",
       "disconnectedToast": "Отключено: {name}"
+    },
+    "emptyState": {
+      "title": "Нет доступных региональных или организационных агентов",
+      "description": "Подключите проект Foundry ниже, чтобы увидеть его агентов."
     }
   },
   "privacy": {

--- a/messages/rw.json
+++ b/messages/rw.json
@@ -1975,6 +1975,10 @@
       "technicalDetails": "Ibisobanuro bya tekiniki",
       "agentCountLabel": "Abakozi {count}",
       "disconnectedToast": "Bikuweho {name}"
+    },
+    "emptyState": {
+      "title": "Nta bahagarariye akarere cyangwa umuryango babonetse",
+      "description": "Huzwa umushinga wa Foundry hasi kugirango ubone abahagarariye bawugize."
     }
   },
   "privacy": {

--- a/messages/sg.json
+++ b/messages/sg.json
@@ -1975,6 +1975,10 @@
       "technicalDetails": "Detay ti teknik",
       "agentCountLabel": "{count} agents",
       "disconnectedToast": "Adèkpété {name}"
+    },
+    "emptyState": {
+      "title": "Gbêtî mbi tene na kombéné / organizasion na mbi",
+      "description": "Sôkô tî Foundry project na wàâ nî so ô bûku na gbêtî na yeke."
     }
   },
   "privacy": {

--- a/messages/si.json
+++ b/messages/si.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "තාක්ෂණික විස්තර",
       "agentCountLabel": "නියෝජිතයන් {count} ක්",
       "disconnectedToast": "{name} අනහිත් විය"
+    },
+    "emptyState": {
+      "title": "ප්‍රාදේශීය / සංවිධාන නියෝජිතයන් නොමැත",
+      "description": "එහි නියෝජිතයන් සොයා බැලීමට පහත Foundry ව්‍යාපෘතියක් සම්බන්ධ කරන්න."
     }
   },
   "privacy": {

--- a/messages/so.json
+++ b/messages/so.json
@@ -1975,6 +1975,10 @@
       "technicalDetails": "Faahfaahin farsamo",
       "agentCountLabel": "{count} wakiil",
       "disconnectedToast": "Waxaa la xog gooyay {name}"
+    },
+    "emptyState": {
+      "title": "Ma jiraan wakiillo goboleed / urur ah oo la heli karo",
+      "description": "Ku xidh mashruuca Foundry hoos si aad u aragto wakiilladiisa."
     }
   },
   "privacy": {

--- a/messages/sr.json
+++ b/messages/sr.json
@@ -1975,6 +1975,10 @@
       "technicalDetails": "Tehnički detalji",
       "agentCountLabel": "{count} agenata",
       "disconnectedToast": "Prekinuta veza sa {name}"
+    },
+    "emptyState": {
+      "title": "Nema dostupnih regionalnih / organizacionih agenata",
+      "description": "Povežite Foundry projekat ispod da biste otkrili njegove agente."
     }
   },
   "privacy": {

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "Teknisk information",
       "agentCountLabel": "{count} agenter",
       "disconnectedToast": "Kopplade från {name}"
+    },
+    "emptyState": {
+      "title": "Inga regionala eller organisatoriska agenter tillgängliga",
+      "description": "Anslut ett Foundry-projekt nedan för att hitta dess agenter."
     }
   },
   "privacy": {

--- a/messages/sw.json
+++ b/messages/sw.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "Maelezo ya kiufundi",
       "agentCountLabel": "Wakala {count}",
       "disconnectedToast": "Imekatishwa {name}"
+    },
+    "emptyState": {
+      "title": "Hakuna mawakala wa kanda/taasisi waliopo",
+      "description": "Unganisha mradi wa Foundry hapo chini ili kupata mawakala wake."
     }
   },
   "privacy": {

--- a/messages/ta.json
+++ b/messages/ta.json
@@ -1975,6 +1975,10 @@
       "technicalDetails": "தொழில்நுட்ப விவரங்கள்",
       "agentCountLabel": "{count} முகவர்கள்",
       "disconnectedToast": "{name} துண்டிக்கப்பட்டது"
+    },
+    "emptyState": {
+      "title": "பிராந்திய / அமைப்பு முகவர்கள் எதுவும் கிடைக்கவில்லை",
+      "description": "முகவர்களை கண்டறிய கீழே உள்ள Foundry திட்டத்தை இணைக்கவும்."
     }
   },
   "privacy": {

--- a/messages/te.json
+++ b/messages/te.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "టెక్నికల్ వివరాలు",
       "agentCountLabel": "{count} ఏజెంట్‌లు",
       "disconnectedToast": "{name} డిస్‌కనెక్ట్ అయింది"
+    },
+    "emptyState": {
+      "title": "ప్రాంతీయ / సంస్థాగత ఏజెంట్లు లేవు",
+      "description": "దాని ఏజెంట్లను కనుగొనడానికి క్రింద ఇచ్చిన Foundry ప్రాజెక్టుని కనెక్ట్ చేయండి."
     }
   },
   "privacy": {

--- a/messages/tg.json
+++ b/messages/tg.json
@@ -1975,6 +1975,10 @@
       "technicalDetails": "Тафсилоти техникӣ",
       "agentCountLabel": "{count} агент",
       "disconnectedToast": "{name} ҷудо шуд"
+    },
+    "emptyState": {
+      "title": "Ягон намояндаи минтақавӣ ё ташкилотӣ дастрас нест",
+      "description": "Лоиҳаи Foundry-ро дар поён пайваст кунед, то намояндаҳои онро пайдо намоед."
     }
   },
   "privacy": {

--- a/messages/th.json
+++ b/messages/th.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "รายละเอียดทางเทคนิค",
       "agentCountLabel": "{count} ตัวแทน",
       "disconnectedToast": "ตัดการเชื่อมต่อ {name} แล้ว"
+    },
+    "emptyState": {
+      "title": "ไม่มีตัวแทนระดับภูมิภาค / องค์กร",
+      "description": "เชื่อมต่อโปรเจกต์ Foundry ด้านล่างเพื่อค้นหาตัวแทนของโปรเจกต์นั้น"
     }
   },
   "privacy": {

--- a/messages/ti.json
+++ b/messages/ti.json
@@ -1975,6 +1975,10 @@
       "technicalDetails": "ዝተኣኽበረ ዝርዝር",
       "agentCountLabel": "{count} ውሳነታት",
       "disconnectedToast": "{name} ተቁጺጺ"
+    },
+    "emptyState": {
+      "title": "ናይ ክልል/ኣደባባይ ኤጀንትስ የለን።",
+      "description": "ናይ Foundry ፕሮጀክት ታሕቲ ምያያይ ኤጀንትስ ንክትረዱ ሓበሬታ ይህብ።"
     }
   },
   "privacy": {

--- a/messages/tr.json
+++ b/messages/tr.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "Teknik ayrıntılar",
       "agentCountLabel": "{count} temsilci",
       "disconnectedToast": "{name} bağlantısı kesildi"
+    },
+    "emptyState": {
+      "title": "Bölgesel / kurumsal ajan bulunmuyor",
+      "description": "Ajanlarını görmek için aşağıdan bir Foundry projesi bağlayın."
     }
   },
   "privacy": {

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -1999,6 +1999,10 @@
       "technicalDetails": "Технічні деталі",
       "agentCountLabel": "{count} агентів",
       "disconnectedToast": "Відключено {name}"
+    },
+    "emptyState": {
+      "title": "Немає доступних регіональних або організаційних агентів",
+      "description": "Підключіть проєкт Foundry нижче, щоб переглянути його агентів."
     }
   },
   "privacy": {

--- a/messages/ur.json
+++ b/messages/ur.json
@@ -2001,6 +2001,10 @@
       "technicalDetails": "تکنیکی تفصیلات",
       "agentCountLabel": "{count} ایجنٹس",
       "disconnectedToast": "{name} ڈسکنیکٹ ہوگیا"
+    },
+    "emptyState": {
+      "title": "کوئی علاقائی / تنظیمی ایجنٹس دستیاب نہیں ہیں",
+      "description": "اس کے ایجنٹس دیکھنے کے لیے نیچے ایک Foundry پروجیکٹ کنیکٹ کریں۔"
     }
   },
   "privacy": {

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -2030,6 +2030,10 @@
       "technicalDetails": "Chi tiết kỹ thuật",
       "agentCountLabel": "{count} agent",
       "disconnectedToast": "Đã ngắt kết nối {name}"
+    },
+    "emptyState": {
+      "title": "Không có agent khu vực / tổ chức nào",
+      "description": "Kết nối một dự án Foundry bên dưới để khám phá các agent của dự án."
     }
   },
   "privacy": {

--- a/messages/yo.json
+++ b/messages/yo.json
@@ -1975,6 +1975,10 @@
       "technicalDetails": "Alaye imọ-ẹrọ",
       "agentCountLabel": "{count} àgéntì",
       "disconnectedToast": "Ti yọ {name} kúrò"
+    },
+    "emptyState": {
+      "title": "Kò sí aṣojú agbègbè/tabili tó wà",
+      "description": "Sopọ iṣẹ́ Foundry kan ní isalẹ láti ṣàwárí àwọn aṣojú rẹ."
     }
   },
   "privacy": {

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -2030,6 +2030,10 @@
       "technicalDetails": "技术详情",
       "agentCountLabel": "{count} 个代理",
       "disconnectedToast": "已断开 {name}"
+    },
+    "emptyState": {
+      "title": "暂无区域／组织代理可用",
+      "description": "请在下方连接一个 Foundry 项目以查看其代理。"
     }
   },
   "privacy": {

--- a/messages/zu.json
+++ b/messages/zu.json
@@ -1975,6 +1975,10 @@
       "technicalDetails": "Imininingwane yezobuchwepheshe",
       "agentCountLabel": "Abameli abangama-{count}",
       "disconnectedToast": "Kuxhunywe kude no-{name}"
+    },
+    "emptyState": {
+      "title": "Azikho izithunywa zesifunda / zenhlangano ezitholakalayo",
+      "description": "Xhuma iphrojekthi ye-Foundry ngezansi ukuze uthole izithunywa zayo."
     }
   },
   "privacy": {

--- a/vitest.setup.dom.ts
+++ b/vitest.setup.dom.ts
@@ -153,6 +153,12 @@ const mockMessages: Record<string, unknown> = {
       closeModal: 'Close modal',
     },
   },
+  agentsTab: {
+    emptyState: {
+      title: 'No regional / organization agents available',
+      description: 'Connect a Foundry project below to discover its agents.',
+    },
+  },
   modelSelect: {
     tabs: {
       models: 'Models',


### PR DESCRIPTION
No regional / org agents are approved, which makes the agents tab look broken before connecting to foundry (and also wonky even after).

This is also a state that will still be the case even after the first regional agents are approved.