### PR TITLE
Add feature flag for browse discovery in AgentSourceForm

### DIFF
--- a/__tests__/components/Chat/AgentSourceForm.test.tsx
+++ b/__tests__/components/Chat/AgentSourceForm.test.tsx
@@ -5,6 +5,14 @@ import { AgentSourceForm } from '@/components/Chat/AgentSources/AgentSourceForm'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+// Mutable LaunchDarkly flags — empty by default (so `agentSourceBrowse` is
+// undefined and treated as enabled, i.e. browse discovery available). Individual
+// tests flip `agentSourceBrowse` to false to assert the prod manual-only path.
+const mockFlags: Record<string, unknown> = {};
+vi.mock('launchdarkly-react-client-sdk', () => ({
+  useFlags: () => mockFlags,
+}));
+
 /**
  * Routes the cascading /api/agents/browse calls (and the connection-check
  * /api/agents call) to canned responses by inspecting the request URL.
@@ -40,6 +48,8 @@ describe('AgentSourceForm', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Reset flags between tests (default: browse enabled).
+    for (const k of Object.keys(mockFlags)) delete mockFlags[k];
   });
 
   afterEach(() => {
@@ -79,5 +89,49 @@ describe('AgentSourceForm', () => {
       'namePlaceholder',
     )) as HTMLInputElement;
     await waitFor(() => expect(nameInput.value).toBe('msf-foundry'));
+  });
+
+  it('offers browse discovery and fetches subscriptions when agentSourceBrowse is enabled (default)', async () => {
+    const fetchFn = stubBrowseFetch({
+      subscriptions: [{ id: 'sub-1', name: 'Sub One' }],
+    });
+
+    render(<AgentSourceForm onSave={vi.fn()} onClose={vi.fn()} />);
+
+    // The browse⇄manual toggle is present (in browse mode it reads "enterManually").
+    expect(
+      await screen.findByRole('button', { name: 'enterManually' }),
+    ).toBeInTheDocument();
+    // Browse mode fetches the subscription list on mount.
+    await waitFor(() =>
+      expect(fetchFn).toHaveBeenCalledWith(
+        expect.stringContaining('level=subscriptions'),
+      ),
+    );
+  });
+
+  it('hides browse and never calls /api/agents/browse when agentSourceBrowse is false (prod)', async () => {
+    mockFlags.agentSourceBrowse = false;
+    const fetchFn = stubBrowseFetch({});
+
+    render(<AgentSourceForm onSave={vi.fn()} onClose={vi.fn()} />);
+
+    // Manual entry is forced: the subscription-id input is rendered immediately.
+    expect(
+      await screen.findByPlaceholderText(
+        'e49ac66c-c18d-4586-b132-8f201de8f2c2',
+      ),
+    ).toBeInTheDocument();
+    // No browse toggle in either direction.
+    expect(
+      screen.queryByRole('button', { name: 'enterManually' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'browseResources' }),
+    ).not.toBeInTheDocument();
+    // Crucially, no Azure-resource discovery call is made.
+    expect(fetchFn).not.toHaveBeenCalledWith(
+      expect.stringContaining('/api/agents/browse'),
+    );
   });
 });

--- a/components/Chat/AgentSources/AgentSourceForm.tsx
+++ b/components/Chat/AgentSources/AgentSourceForm.tsx
@@ -8,6 +8,7 @@ import {
   IconPlus,
   IconX,
 } from '@tabler/icons-react';
+import { useFlags } from 'launchdarkly-react-client-sdk';
 import { FC, useCallback, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
@@ -47,6 +48,12 @@ export const AgentSourceForm: FC<AgentSourceFormProps> = ({
   existingSource,
 }) => {
   const t = useTranslations('agents');
+  // Feature flag: when off, hide the "browse Azure resources" discovery affordance
+  // and require manual resource-path entry. Fail-open (unset ⇒ enabled), mirroring
+  // the `exploreBots` pattern in ModelSelect.tsx. Served `false` in prod until the
+  // agent-discovery rollout is announced.
+  const { agentSourceBrowse } = useFlags();
+  const isBrowseEnabled = agentSourceBrowse !== false;
   const [mounted, setMounted] = useState(false);
   const [name, setName] = useState(existingSource?.name || '');
   // Treat an existing source's name as user-owned so autofill never clobbers it.
@@ -69,7 +76,9 @@ export const AgentSourceForm: FC<AgentSourceFormProps> = ({
     ? parseResourcePath(existingSource.resourcePath)
     : null;
 
-  const [inputMode, setInputMode] = useState<'browse' | 'manual'>('browse');
+  const [inputMode, setInputMode] = useState<'browse' | 'manual'>(
+    isBrowseEnabled ? 'browse' : 'manual',
+  );
 
   // Browse state
   const [subscriptions, setSubscriptions] = useState<BrowseItem[]>([]);
@@ -95,16 +104,16 @@ export const AgentSourceForm: FC<AgentSourceFormProps> = ({
     setMounted(true);
   }, []);
 
-  // Load subscriptions on mount
+  // Load subscriptions on mount (skipped when browse discovery is disabled)
   useEffect(() => {
-    if (!mounted) return;
+    if (!mounted || !isBrowseEnabled) return;
     setLoadingSubs(true);
     fetch('/api/agents/browse?level=subscriptions')
       .then((r) => r.json())
       .then((data) => setSubscriptions(data.items || []))
       .catch(() => setSubscriptions([]))
       .finally(() => setLoadingSubs(false));
-  }, [mounted]);
+  }, [mounted, isBrowseEnabled]);
 
   // Load accounts when subscription changes
   const loadAccounts = useCallback((subId: string) => {
@@ -363,17 +372,19 @@ export const AgentSourceForm: FC<AgentSourceFormProps> = ({
             <label className="text-sm font-medium text-gray-900 dark:text-white">
               {t('foundryProjectLabel')}
             </label>
-            <button
-              type="button"
-              onClick={() =>
-                setInputMode(inputMode === 'browse' ? 'manual' : 'browse')
-              }
-              className="text-xs text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
-            >
-              {inputMode === 'browse'
-                ? t('enterManually')
-                : t('browseResources')}
-            </button>
+            {isBrowseEnabled && (
+              <button
+                type="button"
+                onClick={() =>
+                  setInputMode(inputMode === 'browse' ? 'manual' : 'browse')
+                }
+                className="text-xs text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
+              >
+                {inputMode === 'browse'
+                  ? t('enterManually')
+                  : t('browseResources')}
+              </button>
+            )}
           </div>
 
           {inputMode === 'manual' ? (


### PR DESCRIPTION
- Integrate `agentSourceBrowse` flag to conditionally enable or disable Azure resource browsing.
- Default to browse mode unless the flag is explicitly disabled.
- Skip subscription fetch calls and hide browse UI when browsing is disabled.
- Add tests to verify behavior for both enabled and disabled flag states.