### PR TITLE
Fix issue with extra fields in non-openai models (Mistral Large)

### DIFF
--- a/lib/services/chat/handlers/AzureOpenAIHandler.ts
+++ b/lib/services/chat/handlers/AzureOpenAIHandler.ts
@@ -214,7 +214,10 @@ export class AzureOpenAIHandler extends ModelHandler {
     const params: any = {
       model: modelId,
       messages,
-      user: JSON.stringify(user),
+      // Opaque stable identifier only. This field is for provider-side abuse
+      // monitoring — never send profile fields (name, mail, jobTitle, …), which
+      // would leak PII to the model provider on every request.
+      user: user.id,
       stream: streamResponse,
       // Ask the provider to append a terminal usage chunk (empty `choices`,
       // populated `usage`) so real token counts can be captured for

--- a/lib/services/chat/handlers/DeepSeekHandler.ts
+++ b/lib/services/chat/handlers/DeepSeekHandler.ts
@@ -106,10 +106,11 @@ export class DeepSeekHandler extends ModelHandler {
     // Use deployment name if specified (e.g., "DeepSeek-R1")
     const modelToUse = this.getModelIdForRequest(modelId, modelConfig);
 
+    // No `user` field — see StandardOpenAIHandler. Third-party serving
+    // containers behind Foundry reject unknown body keys.
     const params: any = {
       model: modelToUse,
       messages,
-      user: JSON.stringify(user),
       stream: streamResponse,
       // Ask the provider to append a terminal usage chunk (empty `choices`,
       // populated `usage`) so real token counts can be captured for

--- a/lib/services/chat/handlers/StandardOpenAIHandler.ts
+++ b/lib/services/chat/handlers/StandardOpenAIHandler.ts
@@ -61,10 +61,15 @@ export class StandardOpenAIHandler extends ModelHandler {
     // Use deployment name if specified, otherwise fall back to model ID
     const modelToUse = this.getModelIdForRequest(modelId, modelConfig);
 
+    // No `user` field. Models on this path are third-party publishers behind
+    // Azure AI Foundry, and their serving containers validate the request body
+    // strictly (Pydantic `extra="forbid"`) — a Mistral managed-compute
+    // deployment 422s on any key outside its schema, `user` included. The
+    // Foundry unified endpoint tolerates it, but which route a deployment
+    // lands on varies per environment, so we can't rely on that.
     const params: any = {
       model: modelToUse,
       messages,
-      user: JSON.stringify(user),
       stream: streamResponse,
       // Ask the provider to append a terminal usage chunk (empty `choices`,
       // populated `usage`) so real token counts can be captured for

--- a/lib/utils/app/stream/documentSummary.ts
+++ b/lib/utils/app/stream/documentSummary.ts
@@ -227,7 +227,7 @@ async function summarizeChunk(
       ...(supportsTemperature && { temperature: 0.1 }),
       max_completion_tokens: maxCompletionTokens,
       stream: false,
-      user: user.id,
+      ...userFieldFor(modelConfig, user),
     });
 
     console.log(
@@ -252,6 +252,26 @@ async function summarizeChunk(
  * @param args - Configuration for document processing
  * @returns A ReadableStream for streaming responses, or a string for non-streaming
  */
+/**
+ * Builds the optional `user` request field for a summarization call.
+ *
+ * Both helpers in this file are invoked with the *selected chat model*
+ * (`FileProcessor` passes `context.modelId`), so a third-party Foundry model
+ * such as Mistral can land here. Those serving containers validate the body
+ * strictly (Pydantic `extra="forbid"`) and 422 on any key outside their
+ * schema — `user` included, regardless of how small the value is.
+ *
+ * Only the Azure OpenAI path is known to accept it. Fails safe: an unknown or
+ * unmapped model omits the field, since dropping it costs only provider-side
+ * abuse telemetry while sending it can fail the whole request.
+ */
+function userFieldFor(
+  modelConfig: OpenAIModel | undefined,
+  user: Session['user'],
+): { user: string } | Record<string, never> {
+  return modelConfig?.sdk === 'azure-openai' ? { user: user.id } : {};
+}
+
 export async function parseAndQueryFileOpenAI({
   file,
   prompt,
@@ -426,7 +446,7 @@ export async function parseAndQueryFileOpenAI({
     ...(supportsTemperature && { temperature: 0.1 }),
     max_completion_tokens: chunkConfig.maxCompletionTokens,
     stream: stream,
-    user: user.id,
+    ...userFieldFor(modelConfig, user),
   };
 
   console.log(

--- a/lib/utils/app/stream/documentSummary.ts
+++ b/lib/utils/app/stream/documentSummary.ts
@@ -227,7 +227,7 @@ async function summarizeChunk(
       ...(supportsTemperature && { temperature: 0.1 }),
       max_completion_tokens: maxCompletionTokens,
       stream: false,
-      user: JSON.stringify(user),
+      user: user.id,
     });
 
     console.log(
@@ -426,7 +426,7 @@ export async function parseAndQueryFileOpenAI({
     ...(supportsTemperature && { temperature: 0.1 }),
     max_completion_tokens: chunkConfig.maxCompletionTokens,
     stream: stream,
-    user: JSON.stringify(user),
+    user: user.id,
   };
 
   console.log(


### PR DESCRIPTION
- Ensures only the user's stable identifier is sent, reducing the risk of leaking personally identifiable information (PII) to model providers.
- Removes `user` field from requests to handlers that reject unknown body keys.
- Updates documentation for stricter compliance with provider validation rules.

I may want to remove the user bit altogether. I didn't add it and don't know the reasoning.